### PR TITLE
waffle.io Badge

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/syncloud/redirect.png?label=ready&title=Ready)](https://waffle.io/syncloud/redirect)
 [![Build Status](https://travis-ci.org/syncloud/redirect.svg?branch=master)](https://travis-ci.org/syncloud/redirect)
 ### Install dependencies:
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/syncloud/redirect

This was requested by a real person (user vsapronov) on waffle.io, we're not trying to spam you.
