### PR TITLE
Phase 1: docker-based deploy pipeline

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -143,6 +143,8 @@ local build(arch) = [{
             commands: [
                 "apt-get update && apt-get install -y default-mysql-client",
                 "pip install -r integration/requirements.txt",
+                "IP=$(getent hosts www.syncloud.test | awk '{print $1}')",
+                "echo \"$IP syncloud.test api.syncloud.test auth.syncloud.test\" >> /etc/hosts",
                 "cd integration",
                 "py.test -x -vv -s verify.py --deselect verify.py::test_start --deselect verify.py::test_index --domain=syncloud.test --device-host=www.syncloud.test --build-number=${DRONE_BUILD_NUMBER}"
             ],

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -180,6 +180,7 @@ local build(arch) = [{
                 DEPLOY_USER: { from_secret: "uat_deploy_user" },
                 DEPLOY_KEY: { from_secret: "uat_deploy_key" },
                 DEPLOY_URL: { from_secret: "uat_deploy_url" },
+                SMOKE_TOKEN: { from_secret: "uat_smoke_token" },
             },
             commands: [
                 "./ci/deploy-prepare.sh",
@@ -196,6 +197,7 @@ local build(arch) = [{
                 DEPLOY_USER: { from_secret: "prod_deploy_user" },
                 DEPLOY_KEY: { from_secret: "prod_deploy_key" },
                 DEPLOY_URL: { from_secret: "prod_deploy_url" },
+                SMOKE_TOKEN: { from_secret: "prod_smoke_token" },
             },
             commands: [
                 "./ci/deploy-prepare.sh",

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -75,7 +75,7 @@ local build(arch) = [{
                 "pip install -r integration/requirements.txt",
                 "./ci/recreatedb",
                 "cd integration",
-                "py.test -x -vv -s verify.py::test_start verify.py::test_index --domain=syncloud.test --device-host=www.syncloud.test --build-number=${DRONE_BUILD_NUMBER}"
+                "py.test -x -vv -s test-systemd.py --domain=syncloud.test --device-host=www.syncloud.test --build-number=${DRONE_BUILD_NUMBER}"
             ]
         },
         {
@@ -143,10 +143,8 @@ local build(arch) = [{
             commands: [
                 "apt-get update && apt-get install -y sshpass openssh-client default-mysql-client",
                 "pip install -r integration/requirements.txt",
-                "IP=$(getent hosts www.syncloud.test | awk '{print $1}')",
-                "echo \"$IP syncloud.test api.syncloud.test auth.syncloud.test\" >> /etc/hosts",
                 "cd integration",
-                "py.test -x -vv -s verify.py --deselect verify.py::test_start --deselect verify.py::test_index --domain=syncloud.test --device-host=www.syncloud.test --build-number=${DRONE_BUILD_NUMBER}"
+                "py.test -x -vv -s test.py --domain=syncloud.test --device-host=www.syncloud.test --build-number=${DRONE_BUILD_NUMBER}"
             ],
             when: {
                 event: ["push", "tag"],

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -57,7 +57,7 @@ local build(arch) = [{
             ]
         },
         {
-            name: "test-integration",
+            name: "systemd install",
             image: "python:3.9-slim-bullseye",
             environment: {
                 access_key_id: {
@@ -72,10 +72,10 @@ local build(arch) = [{
             },
             commands: [
                 "apt-get update && apt-get install -y sshpass openssh-client default-mysql-client",
-	            "pip install -r integration/requirements.txt",
-	            "./ci/recreatedb",
+                "pip install -r integration/requirements.txt",
+                "./ci/recreatedb",
                 "cd integration",
-                "py.test -x -vv -s verify.py --domain=syncloud.test --device-host=www.syncloud.test --build-number=${DRONE_BUILD_NUMBER}"
+                "py.test -x -vv -s verify.py::test_start verify.py::test_index --domain=syncloud.test --device-host=www.syncloud.test --build-number=${DRONE_BUILD_NUMBER}"
             ]
         },
         {
@@ -121,6 +121,30 @@ local build(arch) = [{
                 "./ci/deploy-prepare.sh",
                 "./ci/deploy-run.sh " + image_tag,
                 "./ci/deploy-verify.sh",
+            ],
+            when: {
+                event: ["push", "tag"],
+            },
+        },
+        {
+            name: "test-api",
+            image: "python:3.9-slim-bullseye",
+            environment: {
+                access_key_id: {
+                  from_secret: "access_key_id"
+                },
+                secret_access_key: {
+                  from_secret: "secret_access_key"
+                },
+                hosted_zone_id: {
+                  from_secret: "hosted_zone_id"
+                },
+            },
+            commands: [
+                "apt-get update && apt-get install -y default-mysql-client",
+                "pip install -r integration/requirements.txt",
+                "cd integration",
+                "py.test -x -vv -s verify.py --deselect verify.py::test_start --deselect verify.py::test_index --domain=syncloud.test --device-host=www.syncloud.test --build-number=${DRONE_BUILD_NUMBER}"
             ],
             when: {
                 event: ["push", "tag"],

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -4,6 +4,9 @@ local dind = "19.03.8-dind";
 local node = "18.12.0";
 local playwright = "v1.59.1-jammy";
 local platform = "26.04.2";
+local docker_image = "syncloud/redirect";
+local version = "${DRONE_BRANCH}-${DRONE_BUILD_NUMBER}";
+local image_tag = docker_image + ":" + version;
 
 local build(arch) = [{
     kind: "pipeline",
@@ -73,6 +76,54 @@ local build(arch) = [{
             ]
         },
         {
+            name: "docker",
+            image: "plugins/docker:20.18",
+            settings: {
+                repo: docker_image,
+                username: { from_secret: "DOCKER_USERNAME" },
+                password: { from_secret: "DOCKER_PASSWORD" },
+                tags: [
+                    version,
+                    "${DRONE_BRANCH}",
+                ],
+            },
+            when: {
+                event: ["push", "tag"],
+            },
+        },
+        {
+            name: "docker latest",
+            image: "plugins/docker:20.18",
+            settings: {
+                repo: docker_image,
+                username: { from_secret: "DOCKER_USERNAME" },
+                password: { from_secret: "DOCKER_PASSWORD" },
+                tags: ["latest"],
+            },
+            when: {
+                event: ["push"],
+                branch: ["stable"],
+            },
+        },
+        {
+            name: "deploy test",
+            image: "debian:bookworm-slim",
+            environment: {
+                DEPLOY_HOST: "www.syncloud.test",
+                DEPLOY_USER: "root",
+                DEPLOY_URL: "https://api.syncloud.test",
+            },
+            commands: [
+                "./ci/test-init.sh",
+                "./ci/deploy-prepare.sh",
+                "./ci/deploy-run.sh " + image_tag,
+                "./ci/deploy-verify.sh",
+            ],
+            when: {
+                event: ["push", "tag"],
+            },
+        },
+        {
             name: "test-ui-desktop",
             image: "mcr.microsoft.com/playwright:" + playwright,
             environment: {
@@ -93,6 +144,38 @@ local build(arch) = [{
             commands: [
                 "./ci/ui.sh mobile"
             ]
+        },
+        {
+            name: "deploy uat",
+            image: "debian:bookworm-slim",
+            environment: {
+                DEPLOY_HOST: { from_secret: "uat_deploy_host" },
+                DEPLOY_USER: { from_secret: "uat_deploy_user" },
+                DEPLOY_KEY: { from_secret: "uat_deploy_key" },
+                DEPLOY_URL: { from_secret: "uat_deploy_url" },
+            },
+            commands: [
+                "./ci/deploy-prepare.sh",
+                "./ci/deploy-run.sh " + image_tag,
+                "./ci/deploy-verify.sh",
+            ],
+            when: { event: ["push"] },
+        },
+        {
+            name: "deploy prod",
+            image: "debian:bookworm-slim",
+            environment: {
+                DEPLOY_HOST: { from_secret: "prod_deploy_host" },
+                DEPLOY_USER: { from_secret: "prod_deploy_user" },
+                DEPLOY_KEY: { from_secret: "prod_deploy_key" },
+                DEPLOY_URL: { from_secret: "prod_deploy_url" },
+            },
+            commands: [
+                "./ci/deploy-prepare.sh",
+                "./ci/deploy-run.sh " + image_tag,
+                "./ci/deploy-verify.sh",
+            ],
+            when: { event: ["push"], branch: ["stable"] },
         },
         {
             name: "artifact",

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -31,14 +31,17 @@ local build(arch) = [{
             ]
         },
         {
+            name: "test backend",
+            image: "golang:" + go,
+            commands: [
+                "./backend/test.sh",
+            ]
+        },
+        {
             name: "build backend",
             image: "golang:" + go,
             commands: [
-                "cd backend",
-                "go test ./... -cover",
-                "go build -ldflags '-linkmode external -extldflags -static' -o ../build/bin/api ./cmd/api",
-                "go build -ldflags '-linkmode external -extldflags -static' -o ../build/bin/www ./cmd/www",
-                "go build -ldflags '-linkmode external -extldflags -static' -o ../build/bin/cli ./cmd/cli",
+                "./backend/build.sh ${DRONE_BUILD_NUMBER}",
             ]
         },
         {

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -180,7 +180,6 @@ local build(arch) = [{
                 DEPLOY_USER: { from_secret: "uat_deploy_user" },
                 DEPLOY_KEY: { from_secret: "uat_deploy_key" },
                 DEPLOY_URL: { from_secret: "uat_deploy_url" },
-                SMOKE_TOKEN: { from_secret: "uat_smoke_token" },
             },
             commands: [
                 "./ci/deploy-prepare.sh",
@@ -197,7 +196,6 @@ local build(arch) = [{
                 DEPLOY_USER: { from_secret: "prod_deploy_user" },
                 DEPLOY_KEY: { from_secret: "prod_deploy_key" },
                 DEPLOY_URL: { from_secret: "prod_deploy_url" },
-                SMOKE_TOKEN: { from_secret: "prod_smoke_token" },
             },
             commands: [
                 "./ci/deploy-prepare.sh",

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -247,7 +247,7 @@ local build(arch) = [{
         },
         {
             name: "www.syncloud.test",
-            image: "syncloud/platform-bookworm-amd64:" + platform,
+            image: "syncloud/bootstrap-bookworm-amd64:" + platform,
             privileged: true,
             volumes: [
                 {

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -141,7 +141,7 @@ local build(arch) = [{
                 },
             },
             commands: [
-                "apt-get update && apt-get install -y default-mysql-client",
+                "apt-get update && apt-get install -y sshpass openssh-client default-mysql-client",
                 "pip install -r integration/requirements.txt",
                 "IP=$(getent hosts www.syncloud.test | awk '{print $1}')",
                 "echo \"$IP syncloud.test api.syncloud.test auth.syncloud.test\" >> /etc/hosts",

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ _site
 venv
 build
 *.tar.gz
-api
+/api
+.replies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4-bookworm AS builder
+FROM golang:1.20.4-buster AS builder
 WORKDIR /src
 COPY backend/go.mod backend/go.sum ./
 RUN go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.20.4-bookworm AS builder
+WORKDIR /src
+COPY backend/go.mod backend/go.sum ./
+RUN go mod download
+COPY backend/ ./
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/api ./cmd/api \
+ && CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/www ./cmd/www \
+ && CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/cli ./cmd/cli
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=builder /out/api /usr/local/bin/api
+COPY --from=builder /out/www /usr/local/bin/www
+COPY --from=builder /out/cli /usr/local/bin/cli
+COPY emails /app/emails

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,5 @@
-FROM golang:1.20.4-buster AS builder
-WORKDIR /src
-COPY backend/go.mod backend/go.sum ./
-RUN go mod download
-COPY backend/ ./
-RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/api ./cmd/api \
- && CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/www ./cmd/www \
- && CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/cli ./cmd/cli
-
 FROM gcr.io/distroless/static-debian12
-COPY --from=builder /out/api /usr/local/bin/api
-COPY --from=builder /out/www /usr/local/bin/www
-COPY --from=builder /out/cli /usr/local/bin/cli
+COPY build/bin/api /usr/local/bin/api
+COPY build/bin/www /usr/local/bin/www
+COPY build/bin/cli /usr/local/bin/cli
 COPY emails /app/emails

--- a/backend/build.sh
+++ b/backend/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -ex
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+VERSION=${1:-0}
+BUILD_DIR=${DIR}/../build/bin
+mkdir -p "${BUILD_DIR}"
+cd "$DIR"
+
+GIT_SHA=${DRONE_COMMIT_SHA:-unknown}
+BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS="-s -w \
+    -X github.com/syncloud/redirect/version.GitSha=${GIT_SHA} \
+    -X github.com/syncloud/redirect/version.BuildNumber=${VERSION} \
+    -X github.com/syncloud/redirect/version.BuildTime=${BUILD_TIME}"
+
+export CGO_ENABLED=0
+
+go build -ldflags "${LDFLAGS}" -o "${BUILD_DIR}/api" ./cmd/api
+go build -ldflags "${LDFLAGS}" -o "${BUILD_DIR}/www" ./cmd/www
+go build -ldflags "${LDFLAGS}" -o "${BUILD_DIR}/cli" ./cmd/cli

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/syncloud/redirect/db"
 	"github.com/syncloud/redirect/dns"
@@ -10,9 +12,11 @@ import (
 	"github.com/syncloud/redirect/rest"
 	"github.com/syncloud/redirect/service"
 	"github.com/syncloud/redirect/user"
+	"github.com/syncloud/redirect/version"
 )
 
 func main() {
+	fmt.Printf("redirect api build=%s sha=%s time=%s\n", version.BuildNumber, version.GitSha, version.BuildTime)
 	var configFile string
 	var secretFile string
 	var mailDir string

--- a/backend/cmd/cli/main.go
+++ b/backend/cmd/cli/main.go
@@ -6,9 +6,11 @@ import (
 	"github.com/syncloud/redirect/ioc"
 	"github.com/syncloud/redirect/log"
 	"github.com/syncloud/redirect/subscription"
+	"github.com/syncloud/redirect/version"
 )
 
 func main() {
+	fmt.Printf("redirect cli build=%s sha=%s time=%s\n", version.BuildNumber, version.GitSha, version.BuildTime)
 	var configFile string
 	var secretFile string
 	var mailDir string

--- a/backend/cmd/www/main.go
+++ b/backend/cmd/www/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/syncloud/redirect/db"
 	"github.com/syncloud/redirect/ioc"
@@ -8,9 +10,11 @@ import (
 	"github.com/syncloud/redirect/metrics"
 	"github.com/syncloud/redirect/rest"
 	"github.com/syncloud/redirect/service"
+	"github.com/syncloud/redirect/version"
 )
 
 func main() {
+	fmt.Printf("redirect www build=%s sha=%s time=%s\n", version.BuildNumber, version.GitSha, version.BuildTime)
 	var configFile string
 	var secretFile string
 	var mailDir string

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -ex
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+cd "$DIR"
+
+go test ./... -cover

--- a/backend/version/version.go
+++ b/backend/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var (
+	GitSha      = "unknown"
+	BuildNumber = "0"
+	BuildTime   = "unknown"
+)

--- a/ci/deploy-prepare.sh
+++ b/ci/deploy-prepare.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -ex
+
+if ! command -v ssh >/dev/null; then
+    apt-get update
+    apt-get install -y openssh-client
+fi
+
+KEYFILE=/tmp/_deploy_key
+if [ ! -f "$KEYFILE" ]; then
+    set +x
+    printf '%s\n' "$DEPLOY_KEY" > "$KEYFILE"
+    set -x
+    chmod 600 "$KEYFILE"
+fi
+
+SSH="ssh -i $KEYFILE -o StrictHostKeyChecking=no"
+SCP="scp -i $KEYFILE -o StrictHostKeyChecking=no -r"
+REMOTE="${DEPLOY_USER}@${DEPLOY_HOST}"
+
+$SSH $REMOTE "sudo -n rm -rf /tmp/syncloud-redirect && mkdir -p /tmp/syncloud-redirect"
+$SCP deploy "${REMOTE}:/tmp/syncloud-redirect/"

--- a/ci/deploy-run.sh
+++ b/ci/deploy-run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -ex
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 <docker-tag>" >&2
+    exit 1
+fi
+TAG=$1
+
+KEYFILE=/tmp/_deploy_key
+SSH="ssh -i $KEYFILE -o StrictHostKeyChecking=no"
+REMOTE="${DEPLOY_USER}@${DEPLOY_HOST}"
+
+$SSH $REMOTE "sudo -n bash /tmp/syncloud-redirect/deploy/deploy.sh $TAG"

--- a/ci/deploy-verify.sh
+++ b/ci/deploy-verify.sh
@@ -6,6 +6,14 @@ if ! command -v curl >/dev/null; then
     apt-get install -y curl
 fi
 
+URL_HOST=$(echo "$DEPLOY_URL" | sed -E 's|https?://([^/:]+).*|\1|')
+if ! getent hosts "$URL_HOST" >/dev/null 2>&1; then
+    IP=$(getent hosts "$DEPLOY_HOST" | awk '{print $1}')
+    if [ -n "$IP" ]; then
+        echo "$IP $URL_HOST" >> /etc/hosts
+    fi
+fi
+
 KEYFILE=/tmp/_deploy_key
 SSH="ssh -i $KEYFILE -o StrictHostKeyChecking=no"
 REMOTE="${DEPLOY_USER}@${DEPLOY_HOST}"

--- a/ci/deploy-verify.sh
+++ b/ci/deploy-verify.sh
@@ -55,14 +55,3 @@ if ! echo "$db_body" | grep -q "unknown domain update token"; then
     exit 1
 fi
 echo "DB smoke OK"
-
-if [ -n "${SMOKE_TOKEN:-}" ]; then
-    body=$(curl -k -s -X POST "${DEPLOY_URL}/domain/update" \
-        -H 'Content-Type: application/json' \
-        -d "{\"token\":\"${SMOKE_TOKEN}\",\"ipv4_enabled\":true}")
-    echo "smoke /domain/update response: $body"
-    if ! echo "$body" | grep -q '"success":true'; then
-        echo "smoke /domain/update failed"
-        exit 1
-    fi
-fi

--- a/ci/deploy-verify.sh
+++ b/ci/deploy-verify.sh
@@ -47,6 +47,15 @@ if [ "$web_code" != "200" ]; then
 fi
 echo "web UI OK ($web_code)"
 
+db_body=$(curl -k -s -X POST "${DEPLOY_URL}/domain/update" \
+    -H 'Content-Type: application/json' \
+    -d '{"token":"00000000-0000-0000-0000-000000000000","ipv4_enabled":true}')
+if ! echo "$db_body" | grep -q "unknown domain update token"; then
+    echo "DB smoke failed; /domain/update with bogus token returned: $db_body"
+    exit 1
+fi
+echo "DB smoke OK"
+
 if [ -n "${SMOKE_TOKEN:-}" ]; then
     body=$(curl -k -s -X POST "${DEPLOY_URL}/domain/update" \
         -H 'Content-Type: application/json' \

--- a/ci/deploy-verify.sh
+++ b/ci/deploy-verify.sh
@@ -33,7 +33,3 @@ if [ "$code" != "200" ]; then
     $SSH $REMOTE sudo -n docker logs redirect-www 2>&1 | tail -40 || true
     exit 1
 fi
-
-echo "=== post-migration host state ==="
-$SSH $REMOTE "ls -la /var/www/redirect/ /var/www/redirect/current/ /var/www/redirect/current/bin/ 2>&1 | head -40" || true
-$SSH $REMOTE "readlink /var/www/redirect/current; which mysqldump" || true

--- a/ci/deploy-verify.sh
+++ b/ci/deploy-verify.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -ex
+
+if ! command -v curl >/dev/null; then
+    apt-get update
+    apt-get install -y curl
+fi
+
+KEYFILE=/tmp/_deploy_key
+SSH="ssh -i $KEYFILE -o StrictHostKeyChecking=no"
+REMOTE="${DEPLOY_USER}@${DEPLOY_HOST}"
+
+for i in $(seq 1 60); do
+    code=$(curl -k -s -o /dev/null -w "%{http_code}" "${DEPLOY_URL}/status" || echo 000)
+    if [ "$code" = "200" ]; then
+        echo "OK ($code)"
+        break
+    fi
+    sleep 2
+done
+if [ "$code" != "200" ]; then
+    echo "redirect did not come up: last http_code=$code"
+    $SSH $REMOTE sudo -n docker ps -a 2>&1 || true
+    $SSH $REMOTE sudo -n docker logs redirect-api 2>&1 | tail -40 || true
+    $SSH $REMOTE sudo -n docker logs redirect-www 2>&1 | tail -40 || true
+    exit 1
+fi

--- a/ci/deploy-verify.sh
+++ b/ci/deploy-verify.sh
@@ -49,7 +49,7 @@ echo "web UI OK ($web_code)"
 
 db_body=$(curl -k -s -X POST "${DEPLOY_URL}/domain/update" \
     -H 'Content-Type: application/json' \
-    -d '{"token":"00000000-0000-0000-0000-000000000000","ipv4_enabled":true}')
+    -d '{"token":"00000000-0000-0000-0000-000000000000","ipv4_enabled":true,"web_protocol":"https","web_local_port":443}')
 if ! echo "$db_body" | grep -q "unknown domain update token"; then
     echo "DB smoke failed; /domain/update with bogus token returned: $db_body"
     exit 1

--- a/ci/deploy-verify.sh
+++ b/ci/deploy-verify.sh
@@ -7,12 +7,18 @@ if ! command -v curl >/dev/null; then
 fi
 
 URL_HOST=$(echo "$DEPLOY_URL" | sed -E 's|https?://([^/:]+).*|\1|')
-if ! getent hosts "$URL_HOST" >/dev/null 2>&1; then
-    IP=$(getent hosts "$DEPLOY_HOST" | awk '{print $1}')
-    if [ -n "$IP" ]; then
-        echo "$IP $URL_HOST" >> /etc/hosts
-    fi
-fi
+WWW_URL=$(echo "$DEPLOY_URL" | sed -E 's|//api\.|//www.|')
+WWW_HOST=$(echo "$WWW_URL" | sed -E 's|https?://([^/:]+).*|\1|')
+
+resolve_alias() {
+    local host=$1
+    if getent hosts "$host" >/dev/null 2>&1; then return; fi
+    local ip
+    ip=$(getent hosts "$DEPLOY_HOST" | awk '{print $1}')
+    [ -n "$ip" ] && echo "$ip $host" >> /etc/hosts
+}
+resolve_alias "$URL_HOST"
+resolve_alias "$WWW_HOST"
 
 KEYFILE=/tmp/_deploy_key
 SSH="ssh -i $KEYFILE -o StrictHostKeyChecking=no"
@@ -32,4 +38,22 @@ if [ "$code" != "200" ]; then
     $SSH $REMOTE sudo -n docker logs redirect-api 2>&1 | tail -40 || true
     $SSH $REMOTE sudo -n docker logs redirect-www 2>&1 | tail -40 || true
     exit 1
+fi
+
+web_code=$(curl -k -s -o /dev/null -w "%{http_code}" "${WWW_URL}/")
+if [ "$web_code" != "200" ]; then
+    echo "web UI did not respond at ${WWW_URL}/: http_code=$web_code"
+    exit 1
+fi
+echo "web UI OK ($web_code)"
+
+if [ -n "${SMOKE_TOKEN:-}" ]; then
+    body=$(curl -k -s -X POST "${DEPLOY_URL}/domain/update" \
+        -H 'Content-Type: application/json' \
+        -d "{\"token\":\"${SMOKE_TOKEN}\",\"ipv4_enabled\":true}")
+    echo "smoke /domain/update response: $body"
+    if ! echo "$body" | grep -q '"success":true'; then
+        echo "smoke /domain/update failed"
+        exit 1
+    fi
 fi

--- a/ci/deploy-verify.sh
+++ b/ci/deploy-verify.sh
@@ -33,3 +33,7 @@ if [ "$code" != "200" ]; then
     $SSH $REMOTE sudo -n docker logs redirect-www 2>&1 | tail -40 || true
     exit 1
 fi
+
+echo "=== post-migration host state ==="
+$SSH $REMOTE "ls -la /var/www/redirect/ /var/www/redirect/current/ /var/www/redirect/current/bin/ 2>&1 | head -40" || true
+$SSH $REMOTE "readlink /var/www/redirect/current; which mysqldump" || true

--- a/ci/test-init.sh
+++ b/ci/test-init.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+
+apt-get update
+apt-get install -y sshpass openssh-client curl
+
+KEYFILE=/tmp/_deploy_key
+ssh-keygen -t ed25519 -f $KEYFILE -N "" -q
+PUB=$(cat ${KEYFILE}.pub)
+
+TARGET=${DEPLOY_HOST}
+sshpass -p syncloud ssh -o StrictHostKeyChecking=no root@$TARGET \
+    "mkdir -p /root/.ssh && echo '$PUB' >> /root/.ssh/authorized_keys && chmod 600 /root/.ssh/authorized_keys"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -15,6 +15,10 @@ if ! command -v docker >/dev/null 2>&1; then
     apt-get install -y docker.io
 fi
 
+if ! docker info >/dev/null 2>&1; then
+    systemctl start docker
+fi
+
 for svc in redirect.api redirect.www; do
     if systemctl is-active --quiet "$svc"; then
         systemctl stop "$svc"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -16,7 +16,21 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 if ! docker info >/dev/null 2>&1; then
-    systemctl start docker
+    systemctl start docker 2>/dev/null || true
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    nohup dockerd --storage-driver=vfs >/var/log/dockerd.log 2>&1 &
+    for i in $(seq 1 30); do
+        if docker info >/dev/null 2>&1; then break; fi
+        sleep 1
+    done
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "docker daemon failed to start"
+    tail -60 /var/log/dockerd.log 2>/dev/null || true
+    exit 1
 fi
 
 for svc in redirect.api redirect.www; do

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -ex
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 <docker-tag>" >&2
+    exit 1
+fi
+
+TAG=$1
+REDIRECT_DIR=/var/www/redirect
+IMAGE_NAME=syncloud/redirect
+
+if ! command -v docker >/dev/null 2>&1; then
+    apt-get update
+    apt-get install -y docker.io
+fi
+
+for svc in redirect.api redirect.www; do
+    if systemctl is-active --quiet "$svc"; then
+        systemctl stop "$svc"
+    fi
+    if systemctl is-enabled --quiet "$svc" 2>/dev/null; then
+        systemctl disable "$svc"
+    fi
+done
+
+if ! id -u redirect >/dev/null 2>&1; then
+    adduser --disabled-password --gecos "" redirect
+fi
+REDIRECT_UID=$(id -u redirect)
+REDIRECT_GID=$(id -g redirect)
+
+mkdir -p "$REDIRECT_DIR"
+chown "$REDIRECT_UID:$REDIRECT_GID" "$REDIRECT_DIR"
+
+rm -f "$REDIRECT_DIR/redirect.api.socket" "$REDIRECT_DIR/redirect.www.socket"
+
+docker pull "$TAG"
+
+run_container() {
+    local name=$1
+    local bin=$2
+    docker rm -f "$name" 2>/dev/null || true
+    docker run -d \
+        --name "$name" \
+        --restart=unless-stopped \
+        --network=host \
+        --user "$REDIRECT_UID:$REDIRECT_GID" \
+        -v "$REDIRECT_DIR:$REDIRECT_DIR" \
+        "$TAG" "/usr/local/bin/$bin" --mail-dir /app/emails
+}
+
+run_container redirect-api api
+run_container redirect-www www
+
+for name in redirect-api redirect-www; do
+    for i in $(seq 1 30); do
+        if docker ps -q --filter name="$name" --filter status=running | grep -q .; then
+            break
+        fi
+        sleep 2
+    done
+    if ! docker ps -q --filter name="$name" --filter status=running | grep -q .; then
+        echo "container $name is not running:"
+        docker ps -a --filter name="$name"
+        docker logs "$name" 2>&1 | tail -40
+        exit 1
+    fi
+done
+
+docker image prune -f

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -1,6 +1,7 @@
 from os.path import dirname
 
 from syncloudlib.integration.conftest import *
+from syncloudlib.integration.hosts import add_host_alias
 
 DIR = dirname(__file__)
 
@@ -8,3 +9,8 @@ DIR = dirname(__file__)
 @pytest.fixture(scope="session")
 def project_dir():
     return join(dirname(__file__), '..')
+
+
+@pytest.fixture(scope="session", autouse=True)
+def host_aliases(device_host, domain):
+    add_host_alias('api', device_host, domain)

--- a/integration/test-systemd.py
+++ b/integration/test-systemd.py
@@ -1,0 +1,67 @@
+from os import environ
+from os.path import join
+from subprocess import check_output
+
+import pytest
+import requests
+
+import db
+
+TMP_DIR = '/tmp/syncloud'
+
+
+@pytest.fixture(scope="session")
+def module_setup(request, log_dir, artifact_dir, device):
+    def module_teardown():
+        device.run_ssh('cp /var/log/apache2/error.log {0}'.format(TMP_DIR), throw=False)
+        device.run_ssh('cp /var/log/apache2/redirect_rest-error.log {0}'.format(TMP_DIR), throw=False)
+        device.run_ssh('cp /var/log/apache2/redirect_rest-access.log {0}'.format(TMP_DIR), throw=False)
+        device.run_ssh('cp /var/log/apache2/redirect_ssl_rest-error.log {0}'.format(TMP_DIR), throw=False)
+        device.run_ssh('cp /var/log/apache2/redirect_ssl_rest-access.log {0}'.format(TMP_DIR), throw=False)
+        device.run_ssh('cp /var/log/apache2/redirect_ssl_web-access.log {0}'.format(TMP_DIR), throw=False)
+        device.run_ssh('cp /var/log/apache2/redirect_ssl_web-error.log {0}'.format(TMP_DIR), throw=False)
+        device.run_ssh('ls -la /var/log/apache2 > {0}/var.log.apache2.ls.log'.format(TMP_DIR), throw=False)
+        device.run_ssh('ls -la /var/log > {0}/var.log.ls.log'.format(TMP_DIR), throw=False)
+        device.run_ssh('ls -la /var/run > {0}/var.run.ls.log'.format(TMP_DIR), throw=False)
+        device.run_ssh('journalctl | tail -500 > {0}/journalctl.log'.format(TMP_DIR), throw=False)
+        device.run_ssh('cp /var/log/syslog {0}/syslog.log'.format(TMP_DIR), throw=False)
+        check_output("mysql --host=mysql --user=root --password=root redirect -e 'select * from user' > {0}/db-user.log || true".format(artifact_dir), shell=True)
+        check_output("mysql --host=mysql --user=root --password=root redirect -e 'select * from action' > {0}/db-action.log || true".format(artifact_dir), shell=True)
+        check_output("mysql --host=mysql --user=root --password=root redirect -e 'select * from domain' > {0}/db-domain.log || true".format(artifact_dir), shell=True)
+
+        device.scp_from_device('{0}/*'.format(TMP_DIR), artifact_dir)
+        check_output('chmod -R a+r {0}'.format(artifact_dir), shell=True)
+        db.recreate()
+
+    request.addfinalizer(module_teardown)
+
+
+def test_start(module_setup, device, build_number):
+    device.run_ssh('mkdir {0}'.format(TMP_DIR))
+    device.run_ssh("apt-get update --allow-releaseinfo-change")
+    device.run_ssh(
+        "apt-get install -y default-mysql-client default-libmysqlclient-dev apache2 libapache2-mod-wsgi-py3 openssl > {0}/apt.log".format(
+            TMP_DIR))
+    device.scp_to_device("fakecertificate.sh", "/")
+    device.run_ssh("/fakecertificate.sh")
+    device.scp_to_device("../artifact/redirect-{0}.tar.gz".format(build_number), "/")
+    device.scp_to_device("../ci/deploy", "/")
+    # test clean deploy
+    check_output("mysql --host=mysql --user=root --password=root -e 'drop DATABASE redirect'", shell=True)
+    device.run_ssh("cd / && /deploy {0} integration syncloud.test > {1}/deploy.log 2>&1".format(build_number, TMP_DIR))
+    device.run_ssh("sed -i 's#@access_key_id@#{0}#g' /var/www/redirect/secret.cfg".format(environ['access_key_id']),
+                   debug=False)
+    device.run_ssh(
+        "sed -i 's#@secret_access_key@#{0}#g' /var/www/redirect/secret.cfg".format(environ['secret_access_key']),
+        debug=False)
+    device.run_ssh("sed -i 's#@hosted_zone_id@#{0}#g' /var/www/redirect/secret.cfg".format(environ['hosted_zone_id']),
+                   debug=False)
+    device.run_ssh("systemctl restart redirect.api")
+    device.run_ssh("systemctl restart redirect.www")
+
+
+def test_index(domain, artifact_dir):
+    response = requests.get('https://www.{0}'.format(domain), allow_redirects=False, verify=False)
+    assert response.status_code == 200, response.text
+    with open(join(artifact_dir, 'index.html.log'), 'w') as f:
+        f.write(str(response.text))

--- a/integration/test.py
+++ b/integration/test.py
@@ -1,72 +1,13 @@
 import json
-from os import environ
 from os.path import dirname
-from os.path import join
-from subprocess import check_output
 
-import pytest
 import requests
 import time
-from syncloudlib.integration.hosts import add_host_alias
 
-import db
 import smtp
 import api
 
 DIR = dirname(__file__)
-TMP_DIR = '/tmp/syncloud'
-
-
-@pytest.fixture(scope="session")
-def module_setup(request, log_dir, artifact_dir, device):
-    def module_teardown():
-        device.run_ssh('cp /var/log/apache2/error.log {0}'.format(TMP_DIR), throw=False)
-        device.run_ssh('cp /var/log/apache2/redirect_rest-error.log {0}'.format(TMP_DIR), throw=False)
-        device.run_ssh('cp /var/log/apache2/redirect_rest-access.log {0}'.format(TMP_DIR), throw=False)
-        device.run_ssh('cp /var/log/apache2/redirect_ssl_rest-error.log {0}'.format(TMP_DIR), throw=False)
-        device.run_ssh('cp /var/log/apache2/redirect_ssl_rest-access.log {0}'.format(TMP_DIR), throw=False)
-        device.run_ssh('cp /var/log/apache2/redirect_ssl_web-access.log {0}'.format(TMP_DIR), throw=False)
-        device.run_ssh('cp /var/log/apache2/redirect_ssl_web-error.log {0}'.format(TMP_DIR), throw=False)
-        device.run_ssh('ls -la /var/log/apache2 > {0}/var.log.apache2.ls.log'.format(TMP_DIR), throw=False)
-        device.run_ssh('ls -la /var/log > {0}/var.log.ls.log'.format(TMP_DIR), throw=False)
-        device.run_ssh('ls -la /var/run > {0}/var.run.ls.log'.format(TMP_DIR), throw=False)
-        device.run_ssh('journalctl | tail -500 > {0}/journalctl.log'.format(TMP_DIR), throw=False)
-        device.run_ssh('cp /var/log/syslog {0}/syslog.log'.format(TMP_DIR), throw=False)
-        check_output("mysql --host=mysql --user=root --password=root redirect -e 'select * from user' > {0}/db-user.log || true".format(artifact_dir), shell=True)
-        check_output("mysql --host=mysql --user=root --password=root redirect -e 'select * from action' > {0}/db-action.log || true".format(artifact_dir), shell=True)
-        check_output("mysql --host=mysql --user=root --password=root redirect -e 'select * from domain' > {0}/db-domain.log || true".format(artifact_dir), shell=True)
-
-        device.scp_from_device('{0}/*'.format(TMP_DIR), artifact_dir)
-        check_output('chmod -R a+r {0}'.format(artifact_dir), shell=True)
-        db.recreate()
-
-    request.addfinalizer(module_teardown)
-
-
-def test_start(module_setup, device, device_host, domain, build_number):
-    add_host_alias('api', device_host, domain)
-
-    device.run_ssh('mkdir {0}'.format(TMP_DIR))
-    device.run_ssh("apt-get update --allow-releaseinfo-change")
-    device.run_ssh(
-        "apt-get install -y default-mysql-client default-libmysqlclient-dev apache2 libapache2-mod-wsgi-py3 openssl > {0}/apt.log".format(
-            TMP_DIR))
-    device.scp_to_device("fakecertificate.sh", "/")
-    device.run_ssh("/fakecertificate.sh")
-    device.scp_to_device("../artifact/redirect-{0}.tar.gz".format(build_number), "/")
-    device.scp_to_device("../ci/deploy", "/")
-    # test clean deploy
-    check_output("mysql --host=mysql --user=root --password=root -e 'drop DATABASE redirect'", shell=True)
-    device.run_ssh("cd / && /deploy {0} integration syncloud.test > {1}/deploy.log 2>&1".format(build_number, TMP_DIR))
-    device.run_ssh("sed -i 's#@access_key_id@#{0}#g' /var/www/redirect/secret.cfg".format(environ['access_key_id']),
-                   debug=False)
-    device.run_ssh(
-        "sed -i 's#@secret_access_key@#{0}#g' /var/www/redirect/secret.cfg".format(environ['secret_access_key']),
-        debug=False)
-    device.run_ssh("sed -i 's#@hosted_zone_id@#{0}#g' /var/www/redirect/secret.cfg".format(environ['hosted_zone_id']),
-                   debug=False)
-    device.run_ssh("systemctl restart redirect.api")
-    device.run_ssh("systemctl restart redirect.www")
 
 
 def get_domain(update_token, domain):
@@ -76,13 +17,6 @@ def get_domain(update_token, domain):
     assert response.text is not None
     response_data = json.loads(response.text)
     return response_data['data']
-
-
-def test_index(domain, artifact_dir):
-    response = requests.get('https://www.{0}'.format(domain), allow_redirects=False, verify=False)
-    assert response.status_code == 200, response.text
-    with open(join(artifact_dir, 'index.html.log'), 'w') as f:
-        f.write(str(response.text))
 
 
 def test_unauthenticated(domain):

--- a/integration/verify.py
+++ b/integration/verify.py
@@ -47,7 +47,6 @@ def test_start(module_setup, device, device_host, domain, build_number):
     add_host_alias('api', device_host, domain)
 
     device.run_ssh('mkdir {0}'.format(TMP_DIR))
-    device.run_ssh("snap remove platform")
     device.run_ssh("apt-get update --allow-releaseinfo-change")
     device.run_ssh(
         "apt-get install -y default-mysql-client default-libmysqlclient-dev apache2 libapache2-mod-wsgi-py3 openssl > {0}/apt.log".format(


### PR DESCRIPTION
## Summary
- Build a `syncloud/redirect` docker image from a root `Dockerfile` (multi-stage, distroless static, api/www/cli + emails baked in)
- New `deploy/deploy.sh` migrates a host from the existing systemd units (`redirect.api`, `redirect.www`) to two `--restart=unless-stopped` containers, mounting `/var/www/redirect` so unix sockets stay where Apache already proxies to
- Pipeline gains a `deploy test` step that runs the script against the same `www.syncloud.test` service the integration step provisioned via systemd, so the systemd-to-docker migration is exercised end-to-end before any UAT/prod run
- UI tests now run against the docker-migrated host, proving the cutover doesn't break the API or web
- `deploy uat` and `deploy prod` are wired up like the store pipeline; they will be red on CI until `uat_deploy_*` / `prod_deploy_*` secrets are added to Drone — that gating is deliberate so the first real UAT run is the only thing left untested

The legacy tarball + systemd flow is left in place so running prod is undisturbed by this branch. Removal will be a follow-up phase.

## Test plan
- [x] Drone build 1239 — every step before `deploy uat` is green (clone, services, build web/backend, package, test-integration, docker push, deploy test, test-ui-desktop, test-ui-mobile, artifact, all testapi stages); `deploy uat` is red because secrets aren't set; `deploy prod` is skipped on this non-stable branch
- [ ] Add `uat_deploy_host` / `uat_deploy_user` / `uat_deploy_key` / `uat_deploy_url` in Drone and push to trigger a real UAT migration rehearsal
- [ ] After UAT is verified, add `prod_deploy_*` secrets and merge to `stable` to migrate production