### PR TITLE
Collect backend logs from test host on every UI run

### DIFF
--- a/ci/ui.sh
+++ b/ci/ui.sh
@@ -7,7 +7,7 @@ if [[ -z "$PROJECT" ]]; then
     exit 1
 fi
 
-apt-get update && apt-get install -y default-mysql-client
+apt-get update && apt-get install -y default-mysql-client sshpass openssh-client
 ${DIR}/recreatedb
 
 IP=$(getent hosts www.syncloud.test | awk '{print $1}')
@@ -26,5 +26,8 @@ for dir in www/test-results/*/; do
     [[ -f ${dir}video.webm ]] && cp ${dir}video.webm ${OUT}/${name}.webm
     [[ -f ${dir}failure-full-page.png ]] && cp ${dir}failure-full-page.png ${OUT}/${name}.png
 done
+if [[ -d www/test-results/logs ]]; then
+    cp -r www/test-results/logs ${OUT}/logs
+fi
 
 exit $EXIT_CODE

--- a/ci/ui.sh
+++ b/ci/ui.sh
@@ -26,8 +26,6 @@ for dir in www/test-results/*/; do
     [[ -f ${dir}video.webm ]] && cp ${dir}video.webm ${OUT}/${name}.webm
     [[ -f ${dir}failure-full-page.png ]] && cp ${dir}failure-full-page.png ${OUT}/${name}.png
 done
-if [[ -d www/test-results/logs ]]; then
-    cp -r www/test-results/logs ${OUT}/logs
-fi
+cp -r www/test-results/logs ${OUT}/logs
 
 exit $EXIT_CODE

--- a/www/e2e/global-teardown.js
+++ b/www/e2e/global-teardown.js
@@ -1,31 +1,20 @@
-const { execSync } = require('child_process')
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
+const { ssh, scpFrom } = require('./helpers/ssh')
+
+const REMOTE_TMP = '/tmp/syncloud/ui'
 
 module.exports = async function () {
   if (!process.env.CI) return
 
-  const logsDir = path.join(__dirname, '..', 'test-results', 'logs')
-  fs.mkdirSync(logsDir, { recursive: true })
+  const out = path.join(__dirname, '..', 'test-results', 'logs')
+  fs.mkdirSync(out, { recursive: true })
 
-  const ssh = "sshpass -p syncloud ssh -o StrictHostKeyChecking=no root@www.syncloud.test"
-
-  const grab = (label, cmd) => {
-    const target = path.join(logsDir, label)
-    try {
-      const out = execSync(`${ssh} ${cmd}`, { encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024 })
-      fs.writeFileSync(target, out)
-    } catch (e) {
-      const stderr = (e.stderr && e.stderr.toString()) || ''
-      const stdout = (e.stdout && e.stdout.toString()) || ''
-      fs.writeFileSync(target, `# command failed: ${cmd}\n${e.message}\n${stdout}${stderr}`)
-    }
-  }
+  ssh(`rm -rf ${REMOTE_TMP} && mkdir -p ${REMOTE_TMP}`, { throw: false })
 
   for (const c of ['redirect-api', 'redirect-www', 'mail', 'node-exporter']) {
-    grab(`${c}.log`, `'docker logs ${c} 2>&1'`)
+    ssh(`docker logs ${c} > ${REMOTE_TMP}/${c}.log 2>&1`, { throw: false })
   }
-
   for (const f of [
     'redirect_rest-error.log',
     'redirect_ssl_rest-error.log',
@@ -34,6 +23,8 @@ module.exports = async function () {
     'redirect_ssl_rest-access.log',
     'redirect_ssl_web-access.log'
   ]) {
-    grab(`apache-${f}`, `'tail -n 500 /var/log/apache2/${f} 2>/dev/null || true'`)
+    ssh(`tail -n 500 /var/log/apache2/${f} > ${REMOTE_TMP}/apache-${f} 2>/dev/null || true`, { throw: false })
   }
+
+  scpFrom(`${REMOTE_TMP}/*`, out, { throw: false })
 }

--- a/www/e2e/global-teardown.js
+++ b/www/e2e/global-teardown.js
@@ -1,0 +1,39 @@
+const { execSync } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+module.exports = async function () {
+  if (!process.env.CI) return
+
+  const logsDir = path.join(__dirname, '..', 'test-results', 'logs')
+  fs.mkdirSync(logsDir, { recursive: true })
+
+  const ssh = "sshpass -p syncloud ssh -o StrictHostKeyChecking=no root@www.syncloud.test"
+
+  const grab = (label, cmd) => {
+    const target = path.join(logsDir, label)
+    try {
+      const out = execSync(`${ssh} ${cmd}`, { encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024 })
+      fs.writeFileSync(target, out)
+    } catch (e) {
+      const stderr = (e.stderr && e.stderr.toString()) || ''
+      const stdout = (e.stdout && e.stdout.toString()) || ''
+      fs.writeFileSync(target, `# command failed: ${cmd}\n${e.message}\n${stdout}${stderr}`)
+    }
+  }
+
+  for (const c of ['redirect-api', 'redirect-www', 'mail', 'node-exporter']) {
+    grab(`${c}.log`, `'docker logs ${c} 2>&1'`)
+  }
+
+  for (const f of [
+    'redirect_rest-error.log',
+    'redirect_ssl_rest-error.log',
+    'redirect_ssl_web-error.log',
+    'redirect_rest-access.log',
+    'redirect_ssl_rest-access.log',
+    'redirect_ssl_web-access.log'
+  ]) {
+    grab(`apache-${f}`, `'tail -n 500 /var/log/apache2/${f} 2>/dev/null || true'`)
+  }
+}

--- a/www/e2e/helpers/ssh.js
+++ b/www/e2e/helpers/ssh.js
@@ -1,0 +1,34 @@
+const { execFileSync } = require('node:child_process')
+
+const deviceHost = process.env.PLAYWRIGHT_DEVICE_HOST ?? 'www.syncloud.test'
+const sshUser = process.env.PLAYWRIGHT_SSH_USER ?? 'root'
+const sshPassword = process.env.PLAYWRIGHT_SSH_PASSWORD ?? 'syncloud'
+
+const baseArgs = [
+  '-o', 'StrictHostKeyChecking=no',
+  '-o', 'UserKnownHostsFile=/dev/null',
+  '-o', 'LogLevel=ERROR'
+]
+
+function ssh (cmd, opts = {}) {
+  const args = ['-p', sshPassword, 'ssh', ...baseArgs, `${sshUser}@${deviceHost}`, cmd]
+  try {
+    return execFileSync('sshpass', args, { encoding: 'utf8', timeout: 120_000 })
+  } catch (e) {
+    if (opts.throw === false) {
+      return (e.stdout?.toString() ?? '') + (e.stderr?.toString() ?? '')
+    }
+    throw e
+  }
+}
+
+function scpFrom (remote, local, opts = {}) {
+  const args = ['-p', sshPassword, 'scp', ...baseArgs, '-r', `${sshUser}@${deviceHost}:${remote}`, local]
+  try {
+    execFileSync('sshpass', args, { encoding: 'utf8', timeout: 120_000 })
+  } catch (e) {
+    if (opts.throw !== false) throw e
+  }
+}
+
+module.exports = { ssh, scpFrom, deviceHost, sshUser, sshPassword }

--- a/www/playwright.config.js
+++ b/www/playwright.config.js
@@ -5,6 +5,7 @@ const domain = process.env.PLAYWRIGHT_DOMAIN || 'syncloud.test'
 module.exports = defineConfig({
   testDir: './e2e',
   outputDir: 'test-results',
+  globalTeardown: require.resolve('./e2e/global-teardown.js'),
   timeout: 60 * 1000,
   expect: {
     timeout: 10 * 1000


### PR DESCRIPTION
## Summary

Build #1272 failed on a single mobile Playwright test with no backend context to debug — the docker-deploy path never replicated the log scraping that `test-systemd.py` used to do on teardown.

- New `www/e2e/global-teardown.js` runs at end of each Playwright session under `CI=true`: ssh's to `root@www.syncloud.test` and dumps `docker logs redirect-api`, `redirect-www`, `mail`, `node-exporter` plus `tail -n 500` of the six `/var/log/apache2/redirect_*-{access,error}.log` files into `www/test-results/logs/`.
- `playwright.config.js` wires it via `globalTeardown`.
- `ci/ui.sh` apt-installs `sshpass` + `openssh-client` up front and copies `test-results/logs/` alongside the existing `.webm`/`.png` into `artifact/<project>/logs/`.

## Test plan
- [x] CI #1273 all green (no behavior change in tests).
- [x] Artifacts present: `http://ci.syncloud.org:8081/files/redirect/1273/desktop/logs/` and `mobile/logs/` each list 10 files including `redirect-api.log` (9.6 KB, real request flow), `redirect-www.log` (14 KB), `mail.log`, `node-exporter.log`, and six apache logs.
- [ ] Next failing UI build should surface root cause directly from `<project>/logs/redirect-api.log` instead of guesswork from the Playwright video alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)