### PR TITLE
Rogue metric: count unique devices in 24h window, not total requests

### DIFF
--- a/backend/metrics/metrics.go
+++ b/backend/metrics/metrics.go
@@ -6,7 +6,7 @@ type Metrics struct {
 	requests  *prometheus.CounterVec
 	dnsClient *prometheus.CounterVec
 	cleaner   *prometheus.CounterVec
-	rogue     *prometheus.CounterVec
+	rogue     *RogueDevices
 }
 
 func New() *Metrics {
@@ -32,13 +32,7 @@ func New() *Metrics {
 			},
 			[]string{"result"},
 		),
-		rogue: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "redirect_rogue_updates_total",
-				Help: "/domain/update calls whose token doesn't match any active user, by platform_version.",
-			},
-			[]string{"platform_version"},
-		),
+		rogue: NewRogueDevices(),
 	}
 }
 
@@ -54,8 +48,8 @@ func (m *Metrics) Cleaner(result string) {
 	m.cleaner.WithLabelValues(result).Inc()
 }
 
-func (m *Metrics) Rogue(platformVersion string) {
-	m.rogue.WithLabelValues(platformVersion).Inc()
+func (m *Metrics) Rogue(platformVersion, token string) {
+	m.rogue.Mark(platformVersion, token)
 }
 
 func (m *Metrics) Describe(ch chan<- *prometheus.Desc) {

--- a/backend/metrics/rogue.go
+++ b/backend/metrics/rogue.go
@@ -1,0 +1,60 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const rogueWindow = 24 * time.Hour
+
+type rogueKey struct {
+	platformVersion string
+	token           string
+}
+
+type RogueDevices struct {
+	mu   sync.Mutex
+	seen map[rogueKey]time.Time
+	desc *prometheus.Desc
+	now  func() time.Time
+}
+
+func NewRogueDevices() *RogueDevices {
+	return &RogueDevices{
+		seen: make(map[rogueKey]time.Time),
+		desc: prometheus.NewDesc(
+			"redirect_rogue_devices",
+			"Unique rogue devices (distinct update tokens) seen in the last 24h, by platform_version.",
+			[]string{"platform_version"}, nil),
+		now: time.Now,
+	}
+}
+
+func (r *RogueDevices) Mark(platformVersion, token string) {
+	r.mu.Lock()
+	r.seen[rogueKey{platformVersion, token}] = r.now()
+	r.mu.Unlock()
+}
+
+func (r *RogueDevices) Describe(ch chan<- *prometheus.Desc) {
+	ch <- r.desc
+}
+
+func (r *RogueDevices) Collect(ch chan<- prometheus.Metric) {
+	cutoff := r.now().Add(-rogueWindow)
+	counts := map[string]int64{}
+	r.mu.Lock()
+	for k, t := range r.seen {
+		if t.Before(cutoff) {
+			delete(r.seen, k)
+			continue
+		}
+		counts[k.platformVersion]++
+	}
+	r.mu.Unlock()
+	for pv, n := range counts {
+		ch <- prometheus.MustNewConstMetric(r.desc, prometheus.GaugeValue, float64(n), pv)
+	}
+}

--- a/backend/service/domains.go
+++ b/backend/service/domains.go
@@ -304,7 +304,7 @@ func (d *Domains) Update(request model.DomainUpdateRequest, requestIp *string) (
 		return nil, err
 	}
 	if domain == nil {
-		d.metrics.Rogue(ptrOrEmpty(platformVersion))
+		d.metrics.Rogue(ptrOrEmpty(platformVersion), *request.Token)
 		return nil, model.NewServiceError("unknown domain update token")
 	}
 
@@ -313,7 +313,7 @@ func (d *Domains) Update(request model.DomainUpdateRequest, requestIp *string) (
 		return nil, err
 	}
 	if user == nil || !user.Active {
-		d.metrics.Rogue(ptrOrEmpty(platformVersion))
+		d.metrics.Rogue(ptrOrEmpty(platformVersion), *request.Token)
 		return nil, model.NewServiceError("unknown domain update token")
 	}
 	if user.IsLocked() {

--- a/monitoring/grafana/redirect-v2.json
+++ b/monitoring/grafana/redirect-v2.json
@@ -219,19 +219,19 @@
     },
     {
       "type": "timeseries",
-      "title": "Rogue updates by platform_version ($env)",
+      "title": "Rogue devices by platform_version, 24h window ($env)",
       "id": 11,
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
       "targets": [
         {
-          "expr": "sum(rate(redirect_rogue_updates_total{env=\"$env\"}[5m])) by (platform_version)",
+          "expr": "redirect_rogue_devices{env=\"$env\"}",
           "legendFormat": "{{platform_version}}",
           "refId": "A"
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "ops", "min": 0 }
+        "defaults": { "unit": "short", "min": 0 }
       }
     },
     {


### PR DESCRIPTION
## Summary

The previous `redirect_rogue_updates_total{platform_version}` counter ticked once per /domain/update with an unknown token, so a single misbehaving device looping at 1 Hz dominated the dashboard. The metric we actually want is "how many distinct rogue devices per platform_version" within a moving 24h window.

Server-side dedup keyed by `(platform_version, update_token)`:

- `backend/metrics/rogue.go`: `RogueDevices` holds an in-memory `map[(platform_version, token)] -> last_seen`. On every Prom scrape (Collect path) it walks the map, drops entries older than 24h, and emits `redirect_rogue_devices{platform_version}` = count of distinct tokens still in window. Bounded cardinality (one series per platform_version), restart wipes the window — self-heals as devices ping again.
- `backend/metrics/metrics.go`: drop the `*prometheus.CounterVec` field, store `*RogueDevices` instead; `Rogue()` takes both `platform_version` and `token`.
- `backend/service/domains.go`: pass `*request.Token` alongside `platform_version` on both "unknown domain update token" paths.
- `monitoring/grafana/redirect-v2.json`: panel 11 retitled to "Rogue devices by platform_version, 24h window" and switched to plot `redirect_rogue_devices{env=$env}` directly (gauge, unit=short).

This is the only realistic shape — adding `token` as a label to the counter would explode cardinality (one series per unique device).

## Test plan
- [x] `go build ./...` + `go test ./...` green.
- [ ] CI green; UAT deploys.
- [ ] After UAT scrape: dashboard panel "Rogue devices ..." shows one line per platform_version, value = distinct token count, doesn't increase when the same device hammers the endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)