### PR TITLE
Dashboard: rogue panel labels empty platform_version as 'unknown'

### DIFF
--- a/monitoring/grafana/redirect-v2.json
+++ b/monitoring/grafana/redirect-v2.json
@@ -225,7 +225,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
       "targets": [
         {
-          "expr": "redirect_rogue_devices{env=\"$env\"}",
+          "expr": "label_replace(redirect_rogue_devices{env=\"$env\"}, \"platform_version\", \"unknown\", \"platform_version\", \"\")",
           "legendFormat": "{{platform_version}}",
           "refId": "A"
         }

--- a/monitoring/grafana/redirect-v2.json
+++ b/monitoring/grafana/redirect-v2.json
@@ -231,7 +231,17 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "short", "min": 0 }
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "bars",
+            "stacking": { "mode": "normal", "group": "A" },
+            "fillOpacity": 100,
+            "lineWidth": 0,
+            "barAlignment": 0
+          }
+        }
       }
     },
     {
@@ -248,7 +258,17 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "short", "min": 0 }
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "bars",
+            "stacking": { "mode": "normal", "group": "A" },
+            "fillOpacity": 100,
+            "lineWidth": 0,
+            "barAlignment": 0
+          }
+        }
       }
     }
   ]


### PR DESCRIPTION
## Summary
Pure dashboard fix — no backend change. The rogue panel's empty-string platform_version (from the CI smoke check and any device that doesn't send the field) showed as blank in the legend. Wrap the expression in `label_replace(..., "platform_version", "unknown", "platform_version", "")` so it renders as `unknown` instead.

## Test plan
- [x] CI pipeline will redeploy the dashboard via `ci/grafana-deploy.sh`.
- [ ] After UAT deploy: refresh the dashboard; the previously-blank rogue series in the legend should now say `unknown`.