### PR TITLE
relay: nginx SNI demux on 443 + frps behind it (PR 1/3)

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -134,10 +134,14 @@ local build(arch) = [{
                 },
             },
             commands: [
-                "apt-get update && apt-get install -y sshpass openssh-client default-mysql-client",
+                "apt-get update && apt-get install -y sshpass openssh-client default-mysql-client curl openssl",
+                "curl -fL --retry 5 -o /tmp/frp.tgz https://github.com/fatedier/frp/releases/download/v0.70.0/frp_0.70.0_linux_amd64.tar.gz",
+                "tar -xzf /tmp/frp.tgz -C /tmp",
+                "cp /tmp/frp_0.70.0_linux_amd64/frpc /usr/local/bin/frpc",
+                "chmod +x /usr/local/bin/frpc",
                 "pip install -r integration/requirements.txt",
                 "cd integration",
-                "py.test -x -vv -s test.py --domain=syncloud.test --device-host=www.syncloud.test --build-number=${DRONE_BUILD_NUMBER}"
+                "py.test -x -vv -s test.py test_relay.py --domain=syncloud.test --device-host=www.syncloud.test --build-number=${DRONE_BUILD_NUMBER}"
             ],
             when: {
                 event: ["push", "tag"],

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -134,14 +134,10 @@ local build(arch) = [{
                 },
             },
             commands: [
-                "apt-get update && apt-get install -y sshpass openssh-client default-mysql-client curl openssl",
-                "curl -fL --retry 5 -o /tmp/frp.tgz https://github.com/fatedier/frp/releases/download/v0.70.0/frp_0.70.0_linux_amd64.tar.gz",
-                "tar -xzf /tmp/frp.tgz -C /tmp",
-                "cp /tmp/frp_0.70.0_linux_amd64/frpc /usr/local/bin/frpc",
-                "chmod +x /usr/local/bin/frpc",
+                "apt-get update && apt-get install -y sshpass openssh-client default-mysql-client openssl",
                 "pip install -r integration/requirements.txt",
                 "cd integration",
-                "py.test -x -vv -s test.py test_relay.py --domain=syncloud.test --device-host=www.syncloud.test --build-number=${DRONE_BUILD_NUMBER}"
+                "py.test -x -vv -s test.py --domain=syncloud.test --device-host=www.syncloud.test --build-number=${DRONE_BUILD_NUMBER}"
             ],
             when: {
                 event: ["push", "tag"],

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -37,13 +37,15 @@ func main() {
 				userCleaner *user.Cleaner,
 				metricsCollector *metrics.Metrics,
 				relayAuth *relay.AuthServer,
+				relayAccountant *relay.Accountant,
 				config *utils.Config,
 			) error {
-				metricsServer := metrics.NewServer(config.GetApiMetricsAddr(), log.Default(), metricsCollector)
+				metricsServer := metrics.NewServer(config.GetApiMetricsAddr(), log.Default(), metricsCollector, relayAccountant)
 				services := []service.Startable{
 					database,
 					dnsCleaner,
 					userCleaner,
+					relayAccountant,
 					metricsServer,
 					relayAuth,
 					api,

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/syncloud/redirect/ioc"
 	"github.com/syncloud/redirect/log"
 	"github.com/syncloud/redirect/metrics"
+	"github.com/syncloud/redirect/relay"
 	"github.com/syncloud/redirect/rest"
 	"github.com/syncloud/redirect/service"
 	"github.com/syncloud/redirect/user"
@@ -35,6 +36,7 @@ func main() {
 				dnsCleaner *dns.Cleaner,
 				userCleaner *user.Cleaner,
 				metricsCollector *metrics.Metrics,
+				relayAuth *relay.AuthServer,
 				config *utils.Config,
 			) error {
 				metricsServer := metrics.NewServer(config.GetApiMetricsAddr(), log.Default(), metricsCollector)
@@ -43,6 +45,7 @@ func main() {
 					dnsCleaner,
 					userCleaner,
 					metricsServer,
+					relayAuth,
 					api,
 				}
 				for _, s := range services {

--- a/backend/db/mysql.go
+++ b/backend/db/mysql.go
@@ -654,6 +654,36 @@ func (m *MySql) GetDomainCount() (int64, error) {
 	return m.GetCount(`select count(*) from domain`)
 }
 
+func (m *MySql) AddRelayTraffic(name string, yearMonth string, bytes int64) error {
+	stmt, err := m.db.Prepare(
+		"INSERT INTO relay_traffic (name, year_month, bytes) VALUES (?, ?, ?) " +
+			"ON DUPLICATE KEY UPDATE bytes = bytes + VALUES(bytes)")
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	_, err = stmt.Exec(name, yearMonth, bytes)
+	return err
+}
+
+func (m *MySql) GetRelayTrafficMonth(yearMonth string) (map[string]int64, error) {
+	rows, err := m.db.Query("SELECT name, bytes FROM relay_traffic WHERE year_month = ?", yearMonth)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := map[string]int64{}
+	for rows.Next() {
+		var name string
+		var bytes int64
+		if err := rows.Scan(&name, &bytes); err != nil {
+			return nil, err
+		}
+		result[name] = bytes
+	}
+	return result, rows.Err()
+}
+
 func (m *MySql) GetActiveDevicesByPlatformVersion(window time.Duration) (map[string]int64, error) {
 	rows, err := m.db.Query(`
 select coalesce(platform_version, ''), count(*)

--- a/backend/ioc/ioc.go
+++ b/backend/ioc/ioc.go
@@ -254,7 +254,7 @@ func NewContainer(configPath string, secretPath string, mailPath string) (contai
 	}
 
 	err = c.Singleton(func(config *utils.Config) *relay.FrpsMetrics {
-		return relay.NewFrpsMetrics(config.GetFrpsMetricsUrl(), config.GetFrpsAdminUser(), config.GetFrpsAdminPasswordFile())
+		return relay.NewFrpsMetrics(config.GetFrpsMetricsUrl())
 	})
 	if err != nil {
 		return nil, err

--- a/backend/ioc/ioc.go
+++ b/backend/ioc/ioc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/syncloud/redirect/log"
 	"github.com/syncloud/redirect/metrics"
 	"github.com/syncloud/redirect/probe"
+	"github.com/syncloud/redirect/relay"
 	"github.com/syncloud/redirect/rest"
 	"github.com/syncloud/redirect/service"
 	"github.com/syncloud/redirect/smtp"
@@ -246,6 +247,16 @@ func NewContainer(configPath string, secretPath string, mailPath string) (contai
 		amazonDns *dns.AmazonDns,
 	) *service.Certbot {
 		return service.NewCertbot(database, amazonDns)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.Singleton(func(
+		domains *service.Domains,
+		config *utils.Config,
+	) *relay.AuthServer {
+		return relay.NewAuthServer(config.GetRelayPluginAddr(), domains, config.Domain(), logger)
 	})
 	if err != nil {
 		return nil, err

--- a/backend/ioc/ioc.go
+++ b/backend/ioc/ioc.go
@@ -208,7 +208,7 @@ func NewContainer(configPath string, secretPath string, mailPath string) (contai
 		metrics *metrics.Metrics,
 		config *utils.Config,
 	) *service.Domains {
-		return service.NewDomains(amazonDns, database, users, metrics, config.Domain(), config.AwsHostedZoneId(), detector)
+		return service.NewDomains(amazonDns, database, users, metrics, config.Domain(), config.AwsHostedZoneId(), detector, config.GetRelayAddress())
 	})
 	if err != nil {
 		return nil, err

--- a/backend/ioc/ioc.go
+++ b/backend/ioc/ioc.go
@@ -25,6 +25,7 @@ import (
 	"github.com/syncloud/redirect/utils"
 	"go.uber.org/zap"
 	"net/http"
+	"time"
 )
 
 func NewContainer(configPath string, secretPath string, mailPath string) (container.Container, error) {
@@ -252,11 +253,31 @@ func NewContainer(configPath string, secretPath string, mailPath string) (contai
 		return nil, err
 	}
 
+	err = c.Singleton(func(config *utils.Config) *relay.FrpsMetrics {
+		return relay.NewFrpsMetrics(config.GetFrpsMetricsUrl(), config.GetFrpsAdminUser(), config.GetFrpsAdminPasswordFile())
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.Singleton(func(
+		frps *relay.FrpsMetrics,
+		database *db.MySql,
+		config *utils.Config,
+	) *relay.Accountant {
+		interval := time.Duration(config.GetRelayPollIntervalSeconds()) * time.Second
+		return relay.NewAccountant(frps, database, config.GetRelayMonthlyLimitBytes(), interval, logger)
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	err = c.Singleton(func(
 		domains *service.Domains,
+		accountant *relay.Accountant,
 		config *utils.Config,
 	) *relay.AuthServer {
-		return relay.NewAuthServer(config.GetRelayPluginAddr(), domains, config.Domain(), logger)
+		return relay.NewAuthServer(config.GetRelayPluginAddr(), domains, accountant, config.Domain(), logger)
 	})
 	if err != nil {
 		return nil, err

--- a/backend/model/domain_update_request.go
+++ b/backend/model/domain_update_request.go
@@ -13,4 +13,5 @@ type DomainUpdateRequest struct {
 	WebPort         *int    `json:"web_port,omitempty"`
 	Ipv4Enabled     bool    `json:"ipv4_enabled,omitempty"`
 	Ipv6Enabled     bool    `json:"ipv6_enabled,omitempty"`
+	Relay           bool    `json:"relay,omitempty"`
 }

--- a/backend/relay/accounting.go
+++ b/backend/relay/accounting.go
@@ -1,0 +1,150 @@
+package relay
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+)
+
+type TrafficSource interface {
+	Fetch() (map[string]int64, error)
+}
+
+type RelayDb interface {
+	AddRelayTraffic(name string, yearMonth string, bytes int64) error
+	GetRelayTrafficMonth(yearMonth string) (map[string]int64, error)
+}
+
+type Accountant struct {
+	source   TrafficSource
+	db       RelayDb
+	limit    int64
+	interval time.Duration
+	logger   *zap.Logger
+
+	mu      sync.Mutex
+	month   string
+	lastRaw map[string]int64
+	monthly map[string]int64
+	over    map[string]bool
+
+	trafficDesc *prometheus.Desc
+	overDesc    *prometheus.Desc
+}
+
+func NewAccountant(source TrafficSource, db RelayDb, limit int64, interval time.Duration, logger *zap.Logger) *Accountant {
+	return &Accountant{
+		source:      source,
+		db:          db,
+		limit:       limit,
+		interval:    interval,
+		logger:      logger,
+		lastRaw:     map[string]int64{},
+		monthly:     map[string]int64{},
+		over:        map[string]bool{},
+		trafficDesc: prometheus.NewDesc("redirect_relay_traffic_bytes", "Relay traffic this month, by proxy.", []string{"proxy"}, nil),
+		overDesc:    prometheus.NewDesc("redirect_relay_over_limit", "1 if the proxy is over its monthly traffic limit.", []string{"proxy"}, nil),
+	}
+}
+
+func month() string {
+	return time.Now().Format("2006-01")
+}
+
+func (a *Accountant) Start() error {
+	a.mu.Lock()
+	a.month = month()
+	if seed, err := a.db.GetRelayTrafficMonth(a.month); err == nil {
+		a.monthly = seed
+		a.recomputeOver()
+	} else {
+		a.logger.Warn("relay accounting seed failed", zap.Error(err))
+	}
+	a.mu.Unlock()
+	go a.loop()
+	return nil
+}
+
+func (a *Accountant) loop() {
+	ticker := time.NewTicker(a.interval)
+	defer ticker.Stop()
+	for range ticker.C {
+		a.poll()
+	}
+}
+
+func (a *Accountant) poll() {
+	raw, err := a.source.Fetch()
+	if err != nil {
+		a.logger.Warn("relay traffic fetch failed", zap.Error(err))
+		return
+	}
+	current := month()
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if current != a.month {
+		a.month = current
+		a.monthly = map[string]int64{}
+		a.over = map[string]bool{}
+	}
+
+	for name, cur := range raw {
+		last, seen := a.lastRaw[name]
+		a.lastRaw[name] = cur
+		if !seen {
+			continue
+		}
+		delta := cur - last
+		if delta < 0 {
+			delta = cur
+		}
+		if delta <= 0 {
+			continue
+		}
+		a.monthly[name] += delta
+		if err := a.db.AddRelayTraffic(name, current, delta); err != nil {
+			a.logger.Warn("relay traffic persist failed", zap.String("proxy", name), zap.Error(err))
+		}
+	}
+	a.recomputeOver()
+}
+
+func (a *Accountant) recomputeOver() {
+	a.over = map[string]bool{}
+	if a.limit <= 0 {
+		return
+	}
+	for name, bytes := range a.monthly {
+		if bytes >= a.limit {
+			a.over[name] = true
+		}
+	}
+}
+
+func (a *Accountant) OverLimit(name string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.over[name]
+}
+
+func (a *Accountant) Describe(ch chan<- *prometheus.Desc) {
+	ch <- a.trafficDesc
+	ch <- a.overDesc
+}
+
+func (a *Accountant) Collect(ch chan<- prometheus.Metric) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for name, bytes := range a.monthly {
+		ch <- prometheus.MustNewConstMetric(a.trafficDesc, prometheus.GaugeValue, float64(bytes), name)
+		value := 0.0
+		if a.over[name] {
+			value = 1.0
+		}
+		ch <- prometheus.MustNewConstMetric(a.overDesc, prometheus.GaugeValue, value, name)
+	}
+}

--- a/backend/relay/accounting_test.go
+++ b/backend/relay/accounting_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 )
 
@@ -54,14 +55,10 @@ func TestAccountant_BaselineThenAccumulatesDelta(t *testing.T) {
 	a := newAccountant(0, source, db)
 
 	a.poll() // baseline at 1000, nothing added
-	if db.stored["alice"] != 0 {
-		t.Fatalf("expected 0 after baseline, got %d", db.stored["alice"])
-	}
+	assert.Equal(t, int64(0), db.stored["alice"])
 	a.poll() // +500
 	a.poll() // +1500
-	if db.stored["alice"] != 2000 {
-		t.Fatalf("expected 2000 accumulated, got %d", db.stored["alice"])
-	}
+	assert.Equal(t, int64(2000), db.stored["alice"])
 }
 
 func TestAccountant_CounterResetCountsCurrentValue(t *testing.T) {
@@ -72,9 +69,7 @@ func TestAccountant_CounterResetCountsCurrentValue(t *testing.T) {
 	a := newAccountant(0, source, &fakeRelayDb{})
 	a.poll() // baseline 5000
 	a.poll() // reset -> delta = 200
-	if a.monthly["alice"] != 200 {
-		t.Fatalf("expected 200 after reset, got %d", a.monthly["alice"])
-	}
+	assert.Equal(t, int64(200), a.monthly["alice"])
 }
 
 func TestAccountant_OverLimit(t *testing.T) {
@@ -84,13 +79,9 @@ func TestAccountant_OverLimit(t *testing.T) {
 	}}
 	a := newAccountant(4096, source, &fakeRelayDb{})
 	a.poll() // baseline 0
-	if a.OverLimit("alice") {
-		t.Fatal("should not be over limit at baseline")
-	}
+	assert.False(t, a.OverLimit("alice"))
 	a.poll() // +4096 -> at limit
-	if !a.OverLimit("alice") {
-		t.Fatal("should be over limit after exceeding")
-	}
+	assert.True(t, a.OverLimit("alice"))
 }
 
 func TestParseTraffic(t *testing.T) {
@@ -100,10 +91,6 @@ frp_server_traffic_out{name="alice.syncloud.it",type="https"} 800
 frp_server_traffic_in{name="bob.syncloud.it",type="https"} 50
 something_else{name="alice.syncloud.it"} 999`
 	totals := parseTraffic(strings.NewReader(text))
-	if totals["alice.syncloud.it"] != 2000 {
-		t.Fatalf("expected 2000 for alice, got %d", totals["alice.syncloud.it"])
-	}
-	if totals["bob.syncloud.it"] != 50 {
-		t.Fatalf("expected 50 for bob, got %d", totals["bob.syncloud.it"])
-	}
+	assert.Equal(t, int64(2000), totals["alice.syncloud.it"])
+	assert.Equal(t, int64(50), totals["bob.syncloud.it"])
 }

--- a/backend/relay/accounting_test.go
+++ b/backend/relay/accounting_test.go
@@ -1,0 +1,109 @@
+package relay
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type fakeSource struct {
+	values []map[string]int64
+	call   int
+}
+
+func (f *fakeSource) Fetch() (map[string]int64, error) {
+	if f.call >= len(f.values) {
+		return f.values[len(f.values)-1], nil
+	}
+	v := f.values[f.call]
+	f.call++
+	return v, nil
+}
+
+type fakeRelayDb struct {
+	stored map[string]int64
+}
+
+func (f *fakeRelayDb) AddRelayTraffic(name string, yearMonth string, bytes int64) error {
+	if f.stored == nil {
+		f.stored = map[string]int64{}
+	}
+	f.stored[name] += bytes
+	return nil
+}
+
+func (f *fakeRelayDb) GetRelayTrafficMonth(yearMonth string) (map[string]int64, error) {
+	return map[string]int64{}, nil
+}
+
+func newAccountant(limit int64, source TrafficSource, db RelayDb) *Accountant {
+	a := NewAccountant(source, db, limit, time.Minute, zap.NewNop())
+	a.month = month()
+	return a
+}
+
+func TestAccountant_BaselineThenAccumulatesDelta(t *testing.T) {
+	source := &fakeSource{values: []map[string]int64{
+		{"alice": 1000},
+		{"alice": 1500},
+		{"alice": 3000},
+	}}
+	db := &fakeRelayDb{}
+	a := newAccountant(0, source, db)
+
+	a.poll() // baseline at 1000, nothing added
+	if db.stored["alice"] != 0 {
+		t.Fatalf("expected 0 after baseline, got %d", db.stored["alice"])
+	}
+	a.poll() // +500
+	a.poll() // +1500
+	if db.stored["alice"] != 2000 {
+		t.Fatalf("expected 2000 accumulated, got %d", db.stored["alice"])
+	}
+}
+
+func TestAccountant_CounterResetCountsCurrentValue(t *testing.T) {
+	source := &fakeSource{values: []map[string]int64{
+		{"alice": 5000},
+		{"alice": 200}, // frps restarted, counter reset
+	}}
+	a := newAccountant(0, source, &fakeRelayDb{})
+	a.poll() // baseline 5000
+	a.poll() // reset -> delta = 200
+	if a.monthly["alice"] != 200 {
+		t.Fatalf("expected 200 after reset, got %d", a.monthly["alice"])
+	}
+}
+
+func TestAccountant_OverLimit(t *testing.T) {
+	source := &fakeSource{values: []map[string]int64{
+		{"alice": 0},
+		{"alice": 4096},
+	}}
+	a := newAccountant(4096, source, &fakeRelayDb{})
+	a.poll() // baseline 0
+	if a.OverLimit("alice") {
+		t.Fatal("should not be over limit at baseline")
+	}
+	a.poll() // +4096 -> at limit
+	if !a.OverLimit("alice") {
+		t.Fatal("should be over limit after exceeding")
+	}
+}
+
+func TestParseTraffic(t *testing.T) {
+	text := `# HELP frp_server_traffic_in
+frp_server_traffic_in{name="alice.syncloud.it",type="https"} 1200
+frp_server_traffic_out{name="alice.syncloud.it",type="https"} 800
+frp_server_traffic_in{name="bob.syncloud.it",type="https"} 50
+something_else{name="alice.syncloud.it"} 999`
+	totals := parseTraffic(strings.NewReader(text))
+	if totals["alice.syncloud.it"] != 2000 {
+		t.Fatalf("expected 2000 for alice, got %d", totals["alice.syncloud.it"])
+	}
+	if totals["bob.syncloud.it"] != 50 {
+		t.Fatalf("expected 50 for bob, got %d", totals["bob.syncloud.it"])
+	}
+}

--- a/backend/relay/auth.go
+++ b/backend/relay/auth.go
@@ -1,0 +1,127 @@
+package relay
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/syncloud/redirect/model"
+	"go.uber.org/zap"
+)
+
+type Domains interface {
+	GetDomain(token string) (*model.Domain, error)
+}
+
+type AuthServer struct {
+	address string
+	domains Domains
+	suffix  string
+	logger  *zap.Logger
+}
+
+func NewAuthServer(address string, domains Domains, suffix string, logger *zap.Logger) *AuthServer {
+	return &AuthServer{address: address, domains: domains, suffix: suffix, logger: logger}
+}
+
+type pluginRequest struct {
+	Version string          `json:"version"`
+	Op      string          `json:"op"`
+	Content json.RawMessage `json:"content"`
+}
+
+type pluginUser struct {
+	User  string            `json:"user"`
+	Metas map[string]string `json:"metas"`
+	RunId string            `json:"run_id"`
+}
+
+type newProxyContent struct {
+	User          pluginUser        `json:"user"`
+	ProxyName     string            `json:"proxy_name"`
+	ProxyType     string            `json:"proxy_type"`
+	Subdomain     string            `json:"subdomain"`
+	CustomDomains []string          `json:"custom_domains"`
+	Metas         map[string]string `json:"metas"`
+}
+
+type pluginResponse struct {
+	Reject       bool   `json:"reject"`
+	RejectReason string `json:"reject_reason,omitempty"`
+	Unchange     bool   `json:"unchange"`
+}
+
+func (s *AuthServer) Start() error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/plugin", s.handle)
+	srv := &http.Server{Addr: s.address, Handler: mux}
+	s.logger.Info("relay auth plugin listening", zap.String("address", s.address))
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			s.logger.Error("relay auth plugin stopped", zap.Error(err))
+		}
+	}()
+	return nil
+}
+
+func allow() pluginResponse { return pluginResponse{Reject: false, Unchange: true} }
+func deny(r string) pluginResponse {
+	return pluginResponse{Reject: true, RejectReason: r}
+}
+
+func (s *AuthServer) handle(w http.ResponseWriter, r *http.Request) {
+	var req pluginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.write(w, deny("invalid plugin request"))
+		return
+	}
+	if req.Op != "NewProxy" {
+		s.write(w, allow())
+		return
+	}
+	var content newProxyContent
+	if err := json.Unmarshal(req.Content, &content); err != nil {
+		s.write(w, deny("invalid new proxy content"))
+		return
+	}
+	s.write(w, s.Authorize(content))
+}
+
+func (s *AuthServer) Authorize(content newProxyContent) pluginResponse {
+	token := content.User.Metas["token"]
+	if token == "" {
+		token = content.Metas["token"]
+	}
+	if token == "" {
+		return deny("missing token")
+	}
+	domain, err := s.domains.GetDomain(token)
+	if err != nil || domain == nil {
+		s.logger.Warn("relay authorize rejected", zap.String("proxy", content.ProxyName), zap.Error(err))
+		return deny("unknown token")
+	}
+	for _, requested := range s.requestedNames(content) {
+		if strings.EqualFold(requested, domain.Name) {
+			return allow()
+		}
+	}
+	s.logger.Warn("relay authorize domain mismatch",
+		zap.String("owned", domain.Name),
+		zap.Strings("custom_domains", content.CustomDomains),
+		zap.String("subdomain", content.Subdomain))
+	return deny("domain not owned by token")
+}
+
+func (s *AuthServer) requestedNames(content newProxyContent) []string {
+	names := append([]string{}, content.CustomDomains...)
+	if content.Subdomain != "" && s.suffix != "" {
+		names = append(names, fmt.Sprintf("%s.%s", content.Subdomain, s.suffix))
+	}
+	return names
+}
+
+func (s *AuthServer) write(w http.ResponseWriter, resp pluginResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/backend/relay/auth.go
+++ b/backend/relay/auth.go
@@ -14,15 +14,20 @@ type Domains interface {
 	GetDomain(token string) (*model.Domain, error)
 }
 
+type Limiter interface {
+	OverLimit(name string) bool
+}
+
 type AuthServer struct {
 	address string
 	domains Domains
+	limiter Limiter
 	suffix  string
 	logger  *zap.Logger
 }
 
-func NewAuthServer(address string, domains Domains, suffix string, logger *zap.Logger) *AuthServer {
-	return &AuthServer{address: address, domains: domains, suffix: suffix, logger: logger}
+func NewAuthServer(address string, domains Domains, limiter Limiter, suffix string, logger *zap.Logger) *AuthServer {
+	return &AuthServer{address: address, domains: domains, limiter: limiter, suffix: suffix, logger: logger}
 }
 
 type pluginRequest struct {
@@ -44,6 +49,12 @@ type newProxyContent struct {
 	Subdomain     string            `json:"subdomain"`
 	CustomDomains []string          `json:"custom_domains"`
 	Metas         map[string]string `json:"metas"`
+}
+
+type newUserConnContent struct {
+	User      pluginUser `json:"user"`
+	ProxyName string     `json:"proxy_name"`
+	ProxyType string     `json:"proxy_type"`
 }
 
 type pluginResponse struct {
@@ -76,16 +87,32 @@ func (s *AuthServer) handle(w http.ResponseWriter, r *http.Request) {
 		s.write(w, deny("invalid plugin request"))
 		return
 	}
-	if req.Op != "NewProxy" {
+	switch req.Op {
+	case "NewProxy":
+		var content newProxyContent
+		if err := json.Unmarshal(req.Content, &content); err != nil {
+			s.write(w, deny("invalid new proxy content"))
+			return
+		}
+		s.write(w, s.Authorize(content))
+	case "NewUserConn":
+		var content newUserConnContent
+		if err := json.Unmarshal(req.Content, &content); err != nil {
+			s.write(w, deny("invalid new user conn content"))
+			return
+		}
+		s.write(w, s.Enforce(content))
+	default:
 		s.write(w, allow())
-		return
 	}
-	var content newProxyContent
-	if err := json.Unmarshal(req.Content, &content); err != nil {
-		s.write(w, deny("invalid new proxy content"))
-		return
+}
+
+func (s *AuthServer) Enforce(content newUserConnContent) pluginResponse {
+	if s.limiter != nil && s.limiter.OverLimit(content.ProxyName) {
+		s.logger.Warn("relay connection blocked, over monthly limit", zap.String("proxy", content.ProxyName))
+		return deny("monthly traffic limit exceeded")
 	}
-	s.write(w, s.Authorize(content))
+	return allow()
 }
 
 func (s *AuthServer) Authorize(content newProxyContent) pluginResponse {

--- a/backend/relay/auth_test.go
+++ b/backend/relay/auth_test.go
@@ -20,8 +20,16 @@ func (f *fakeDomains) GetDomain(token string) (*model.Domain, error) {
 	return domain, nil
 }
 
+type fakeLimiter struct {
+	over map[string]bool
+}
+
+func (f *fakeLimiter) OverLimit(name string) bool {
+	return f.over[name]
+}
+
 func newServer(byToken map[string]*model.Domain) *AuthServer {
-	return NewAuthServer("127.0.0.1:0", &fakeDomains{byToken: byToken}, "syncloud.it", zap.NewNop())
+	return NewAuthServer("127.0.0.1:0", &fakeDomains{byToken: byToken}, &fakeLimiter{over: map[string]bool{}}, "syncloud.it", zap.NewNop())
 }
 
 func domainNamed(name string) *model.Domain {
@@ -77,5 +85,19 @@ func TestAuthorize_TokenDoesNotOwnRequestedDomain(t *testing.T) {
 	})
 	if !resp.Reject {
 		t.Fatal("expected reject when token owns a different domain")
+	}
+}
+
+func TestEnforce_UnderLimitAllows(t *testing.T) {
+	s := NewAuthServer("127.0.0.1:0", &fakeDomains{}, &fakeLimiter{over: map[string]bool{}}, "syncloud.it", zap.NewNop())
+	if s.Enforce(newUserConnContent{ProxyName: "alice.syncloud.it"}).Reject {
+		t.Fatal("expected allow under limit")
+	}
+}
+
+func TestEnforce_OverLimitRejects(t *testing.T) {
+	s := NewAuthServer("127.0.0.1:0", &fakeDomains{}, &fakeLimiter{over: map[string]bool{"alice.syncloud.it": true}}, "syncloud.it", zap.NewNop())
+	if !s.Enforce(newUserConnContent{ProxyName: "alice.syncloud.it"}).Reject {
+		t.Fatal("expected reject over limit")
 	}
 }

--- a/backend/relay/auth_test.go
+++ b/backend/relay/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/syncloud/redirect/model"
 	"go.uber.org/zap"
 )
@@ -42,9 +43,7 @@ func TestAuthorize_ValidTokenOwnsCustomDomain(t *testing.T) {
 		User:          pluginUser{Metas: map[string]string{"token": "good"}},
 		CustomDomains: []string{"alice.syncloud.it"},
 	})
-	if resp.Reject {
-		t.Fatalf("expected allow, got reject: %s", resp.RejectReason)
-	}
+	assert.False(t, resp.Reject, resp.RejectReason)
 }
 
 func TestAuthorize_ValidTokenOwnsSubdomain(t *testing.T) {
@@ -53,17 +52,13 @@ func TestAuthorize_ValidTokenOwnsSubdomain(t *testing.T) {
 		User:      pluginUser{Metas: map[string]string{"token": "good"}},
 		Subdomain: "alice",
 	})
-	if resp.Reject {
-		t.Fatalf("expected allow, got reject: %s", resp.RejectReason)
-	}
+	assert.False(t, resp.Reject, resp.RejectReason)
 }
 
 func TestAuthorize_MissingToken(t *testing.T) {
 	s := newServer(map[string]*model.Domain{"good": domainNamed("alice.syncloud.it")})
 	resp := s.Authorize(newProxyContent{CustomDomains: []string{"alice.syncloud.it"}})
-	if !resp.Reject {
-		t.Fatal("expected reject for missing token")
-	}
+	assert.True(t, resp.Reject)
 }
 
 func TestAuthorize_UnknownToken(t *testing.T) {
@@ -72,9 +67,7 @@ func TestAuthorize_UnknownToken(t *testing.T) {
 		User:          pluginUser{Metas: map[string]string{"token": "bad"}},
 		CustomDomains: []string{"alice.syncloud.it"},
 	})
-	if !resp.Reject {
-		t.Fatal("expected reject for unknown token")
-	}
+	assert.True(t, resp.Reject)
 }
 
 func TestAuthorize_TokenDoesNotOwnRequestedDomain(t *testing.T) {
@@ -83,21 +76,15 @@ func TestAuthorize_TokenDoesNotOwnRequestedDomain(t *testing.T) {
 		User:          pluginUser{Metas: map[string]string{"token": "good"}},
 		CustomDomains: []string{"bob.syncloud.it"},
 	})
-	if !resp.Reject {
-		t.Fatal("expected reject when token owns a different domain")
-	}
+	assert.True(t, resp.Reject)
 }
 
 func TestEnforce_UnderLimitAllows(t *testing.T) {
 	s := NewAuthServer("127.0.0.1:0", &fakeDomains{}, &fakeLimiter{over: map[string]bool{}}, "syncloud.it", zap.NewNop())
-	if s.Enforce(newUserConnContent{ProxyName: "alice.syncloud.it"}).Reject {
-		t.Fatal("expected allow under limit")
-	}
+	assert.False(t, s.Enforce(newUserConnContent{ProxyName: "alice.syncloud.it"}).Reject)
 }
 
 func TestEnforce_OverLimitRejects(t *testing.T) {
 	s := NewAuthServer("127.0.0.1:0", &fakeDomains{}, &fakeLimiter{over: map[string]bool{"alice.syncloud.it": true}}, "syncloud.it", zap.NewNop())
-	if !s.Enforce(newUserConnContent{ProxyName: "alice.syncloud.it"}).Reject {
-		t.Fatal("expected reject over limit")
-	}
+	assert.True(t, s.Enforce(newUserConnContent{ProxyName: "alice.syncloud.it"}).Reject)
 }

--- a/backend/relay/auth_test.go
+++ b/backend/relay/auth_test.go
@@ -1,0 +1,81 @@
+package relay
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/syncloud/redirect/model"
+	"go.uber.org/zap"
+)
+
+type fakeDomains struct {
+	byToken map[string]*model.Domain
+}
+
+func (f *fakeDomains) GetDomain(token string) (*model.Domain, error) {
+	domain, ok := f.byToken[token]
+	if !ok {
+		return nil, fmt.Errorf("unknown domain update token")
+	}
+	return domain, nil
+}
+
+func newServer(byToken map[string]*model.Domain) *AuthServer {
+	return NewAuthServer("127.0.0.1:0", &fakeDomains{byToken: byToken}, "syncloud.it", zap.NewNop())
+}
+
+func domainNamed(name string) *model.Domain {
+	return &model.Domain{Name: name}
+}
+
+func TestAuthorize_ValidTokenOwnsCustomDomain(t *testing.T) {
+	s := newServer(map[string]*model.Domain{"good": domainNamed("alice.syncloud.it")})
+	resp := s.Authorize(newProxyContent{
+		User:          pluginUser{Metas: map[string]string{"token": "good"}},
+		CustomDomains: []string{"alice.syncloud.it"},
+	})
+	if resp.Reject {
+		t.Fatalf("expected allow, got reject: %s", resp.RejectReason)
+	}
+}
+
+func TestAuthorize_ValidTokenOwnsSubdomain(t *testing.T) {
+	s := newServer(map[string]*model.Domain{"good": domainNamed("alice.syncloud.it")})
+	resp := s.Authorize(newProxyContent{
+		User:      pluginUser{Metas: map[string]string{"token": "good"}},
+		Subdomain: "alice",
+	})
+	if resp.Reject {
+		t.Fatalf("expected allow, got reject: %s", resp.RejectReason)
+	}
+}
+
+func TestAuthorize_MissingToken(t *testing.T) {
+	s := newServer(map[string]*model.Domain{"good": domainNamed("alice.syncloud.it")})
+	resp := s.Authorize(newProxyContent{CustomDomains: []string{"alice.syncloud.it"}})
+	if !resp.Reject {
+		t.Fatal("expected reject for missing token")
+	}
+}
+
+func TestAuthorize_UnknownToken(t *testing.T) {
+	s := newServer(map[string]*model.Domain{"good": domainNamed("alice.syncloud.it")})
+	resp := s.Authorize(newProxyContent{
+		User:          pluginUser{Metas: map[string]string{"token": "bad"}},
+		CustomDomains: []string{"alice.syncloud.it"},
+	})
+	if !resp.Reject {
+		t.Fatal("expected reject for unknown token")
+	}
+}
+
+func TestAuthorize_TokenDoesNotOwnRequestedDomain(t *testing.T) {
+	s := newServer(map[string]*model.Domain{"good": domainNamed("alice.syncloud.it")})
+	resp := s.Authorize(newProxyContent{
+		User:          pluginUser{Metas: map[string]string{"token": "good"}},
+		CustomDomains: []string{"bob.syncloud.it"},
+	})
+	if !resp.Reject {
+		t.Fatal("expected reject when token owns a different domain")
+	}
+}

--- a/backend/relay/frps.go
+++ b/backend/relay/frps.go
@@ -1,0 +1,66 @@
+package relay
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var trafficLine = regexp.MustCompile(`^frp_server_traffic_(?:in|out)\{[^}]*name="([^"]+)"[^}]*\}\s+([0-9.eE+-]+)$`)
+
+type FrpsMetrics struct {
+	url          string
+	user         string
+	passwordFile string
+	client       *http.Client
+}
+
+func NewFrpsMetrics(url string, user string, passwordFile string) *FrpsMetrics {
+	return &FrpsMetrics{
+		url:          url,
+		user:         user,
+		passwordFile: passwordFile,
+		client:       &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func (f *FrpsMetrics) Fetch() (map[string]int64, error) {
+	request, err := http.NewRequest("GET", f.url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if password, err := os.ReadFile(f.passwordFile); err == nil {
+		request.SetBasicAuth(f.user, strings.TrimSpace(string(password)))
+	}
+	response, err := f.client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("frps metrics status %d", response.StatusCode)
+	}
+	return parseTraffic(response.Body), nil
+}
+
+func parseTraffic(reader interface{ Read([]byte) (int, error) }) map[string]int64 {
+	totals := map[string]int64{}
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		match := trafficLine.FindStringSubmatch(scanner.Text())
+		if match == nil {
+			continue
+		}
+		value, err := strconv.ParseFloat(match[2], 64)
+		if err != nil {
+			continue
+		}
+		totals[match[1]] += int64(value)
+	}
+	return totals
+}

--- a/backend/relay/frps.go
+++ b/backend/relay/frps.go
@@ -4,40 +4,27 @@ import (
 	"bufio"
 	"fmt"
 	"net/http"
-	"os"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 )
 
 var trafficLine = regexp.MustCompile(`^frp_server_traffic_(?:in|out)\{[^}]*name="([^"]+)"[^}]*\}\s+([0-9.eE+-]+)$`)
 
 type FrpsMetrics struct {
-	url          string
-	user         string
-	passwordFile string
-	client       *http.Client
+	url    string
+	client *http.Client
 }
 
-func NewFrpsMetrics(url string, user string, passwordFile string) *FrpsMetrics {
+func NewFrpsMetrics(url string) *FrpsMetrics {
 	return &FrpsMetrics{
-		url:          url,
-		user:         user,
-		passwordFile: passwordFile,
-		client:       &http.Client{Timeout: 5 * time.Second},
+		url:    url,
+		client: &http.Client{Timeout: 5 * time.Second},
 	}
 }
 
 func (f *FrpsMetrics) Fetch() (map[string]int64, error) {
-	request, err := http.NewRequest("GET", f.url, nil)
-	if err != nil {
-		return nil, err
-	}
-	if password, err := os.ReadFile(f.passwordFile); err == nil {
-		request.SetBasicAuth(f.user, strings.TrimSpace(string(password)))
-	}
-	response, err := f.client.Do(request)
+	response, err := f.client.Get(f.url)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/service/domains.go
+++ b/backend/service/domains.go
@@ -22,6 +22,7 @@ type Domains struct {
 	domain           string
 	freeHostedZoneId string
 	detector         change.Detector
+	relayAddress     string
 }
 
 type DomainsDb interface {
@@ -56,6 +57,7 @@ func NewDomains(
 	domain string,
 	freeHostedZoneId string,
 	detector change.Detector,
+	relayAddress string,
 ) *Domains {
 	return &Domains{
 		amazonDns:        dnsImpl,
@@ -64,7 +66,8 @@ func NewDomains(
 		metrics:          metrics,
 		domain:           domain,
 		freeHostedZoneId: freeHostedZoneId,
-		detector:         detector}
+		detector:         detector,
+		relayAddress:     relayAddress}
 }
 
 func (d *Domains) GetDomain(token string) (*model.Domain, error) {
@@ -325,6 +328,12 @@ func (d *Domains) Update(request model.DomainUpdateRequest, requestIp *string) (
 	if request.Ipv4Enabled {
 		ipv4 = ip
 		localIpv4 = request.LocalIp
+	}
+	if request.Relay && d.relayAddress != "" {
+		relay := d.relayAddress
+		ipv4 = &relay
+		localIpv4 = nil
+		mapLocalAddress = false
 	}
 
 	var ipv6 *string

--- a/backend/service/domains_test.go
+++ b/backend/service/domains_test.go
@@ -155,7 +155,7 @@ func TestAcquireFreeDomain_ExistingMine(t *testing.T) {
 	db := &DomainsDbStub{found: true, userId: 1}
 	dnsStub := &DnsStub{}
 	users := &DomainsUsersStub{authenticated: true, userId: 1}
-	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{})
+	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{}, "")
 	domain := "test123.syncloud.it"
 	password := "password"
 	email := "test@example.com"
@@ -174,7 +174,7 @@ func TestAcquireFreeDomain_ExistingNotMine(t *testing.T) {
 	db := &DomainsDbStub{found: true, userId: 2}
 	dnsStub := &DnsStub{}
 	users := &DomainsUsersStub{authenticated: true, userId: 1}
-	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{})
+	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{}, "")
 	userDomain := "test.syncloud.it"
 	password := "password"
 	email := "test@example.com"
@@ -194,7 +194,7 @@ func TestAcquireFreeDomain_Available(t *testing.T) {
 	db := &DomainsDbStub{found: false}
 	dnsStub := &DnsStub{}
 	users := &DomainsUsersStub{authenticated: true, userId: 1}
-	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{})
+	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{}, "")
 	domain := "test123.syncloud.it"
 	password := "password"
 	email := "test@example.com"
@@ -214,7 +214,7 @@ func TestAcquirePremiumDomain_FreeUser_NotAvailable(t *testing.T) {
 	db := &DomainsDbStub{found: false}
 	dnsStub := &DnsStub{}
 	users := &DomainsUsersStub{authenticated: true, userId: 1}
-	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{})
+	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{}, "")
 	domain := "example.com"
 	password := "password"
 	email := "test@example.com"
@@ -233,7 +233,7 @@ func TestAcquirePremiumDomain_PremiumUser_Available(t *testing.T) {
 	dnsStub := &DnsStub{}
 	subscriptionId := "1"
 	users := &DomainsUsersStub{authenticated: true, userId: 1, subscriptionId: &subscriptionId}
-	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{})
+	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{}, "")
 	domain := "example.com"
 	password := "password"
 	email := "test@example.com"
@@ -253,7 +253,7 @@ func TestFreeAvailability_SameUser(t *testing.T) {
 	db := &DomainsDbStub{found: true, userId: 1}
 	dnsStub := &DnsStub{}
 	users := &DomainsUsersStub{authenticated: true, userId: 1}
-	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{})
+	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{}, "")
 	domain := "test123.syncloud.it"
 	password := "password"
 	email := "test@example.com"
@@ -269,7 +269,7 @@ func TestFreeAvailability_OtherUser(t *testing.T) {
 	db := &DomainsDbStub{found: true, userId: 2}
 	dnsStub := &DnsStub{}
 	users := &DomainsUsersStub{authenticated: true, userId: 1}
-	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{})
+	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{}, "")
 	domain := "test.syncloud.it"
 	password := "password"
 	email := "test@example.com"
@@ -285,7 +285,7 @@ func TestFreeAvailability_Available(t *testing.T) {
 	db := &DomainsDbStub{found: false}
 	dnsStub := &DnsStub{}
 	users := &DomainsUsersStub{authenticated: true, userId: 1}
-	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{})
+	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{}, "")
 	domain := "test123.syncloud.it"
 	password := "password"
 	email := "test@example.com"
@@ -301,7 +301,7 @@ func TestPremiumAvailability_FreeUser_NotAvailable(t *testing.T) {
 	db := &DomainsDbStub{found: false}
 	dnsStub := &DnsStub{}
 	users := &DomainsUsersStub{authenticated: true, userId: 1}
-	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{})
+	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{}, "")
 	domain := "example.com"
 	password := "password"
 	email := "test@example.com"
@@ -318,7 +318,7 @@ func TestPremiumAvailability_PremiumUser_NotAvailable(t *testing.T) {
 	dnsStub := &DnsStub{}
 	subscriptionId := "1"
 	users := &DomainsUsersStub{authenticated: true, userId: 1, subscriptionId: &subscriptionId}
-	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{})
+	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "", &DetectorStub{}, "")
 	domain := "example.com"
 	password := "password"
 	email := "test@example.com"
@@ -334,7 +334,7 @@ func TestDeleteDomain_Free_DeleteRecords(t *testing.T) {
 	db := &DomainsDbStub{found: true, userId: 1, hostedZoneId: "1"}
 	dnsStub := &DnsStub{}
 	users := &DomainsUsersStub{authenticated: true, userId: 1}
-	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "1", &DetectorStub{})
+	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "1", &DetectorStub{}, "")
 	err := domains.DeleteDomain(1, "test.syncloud.it")
 
 	assert.Nil(t, err)
@@ -349,7 +349,7 @@ func TestDeleteDomain_Premium_DeleteRecordsAndHostedZone(t *testing.T) {
 	db := &DomainsDbStub{found: true, userId: 1, hostedZoneId: "1"}
 	dnsStub := &DnsStub{}
 	users := &DomainsUsersStub{authenticated: true, userId: 1}
-	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "2", &DetectorStub{})
+	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "2", &DetectorStub{}, "")
 	err := domains.DeleteDomain(1, "test.com")
 
 	assert.Nil(t, err)
@@ -364,7 +364,7 @@ func TestDeleteDomain_Premium_DeleteRecordsAndHostedZone_IgnoreNoSuchHostedZoneE
 	db := &DomainsDbStub{found: true, userId: 1, hostedZoneId: "1"}
 	dnsStub := &DnsStub{error: awserr.New(route53.ErrCodeNoSuchHostedZone, "not found", nil)}
 	users := &DomainsUsersStub{authenticated: true, userId: 1}
-	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "2", &DetectorStub{})
+	domains := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "2", &DetectorStub{}, "")
 	err := domains.DeleteDomain(1, "test.com")
 
 	assert.Nil(t, err)
@@ -379,7 +379,7 @@ func TestGetDomains_Free_NoNameServers(t *testing.T) {
 	db := &DomainsDbStub{found: true, userId: 1, hostedZoneId: "1"}
 	dnsStub := &DnsStub{}
 	users := &DomainsUsersStub{authenticated: true, userId: 1}
-	domainService := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "1", &DetectorStub{})
+	domainService := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "1", &DetectorStub{}, "")
 	domains, err := domainService.GetDomains(&model.User{Id: 1})
 
 	assert.Nil(t, err)
@@ -390,7 +390,7 @@ func TestGetDomains_Premium_NameServers(t *testing.T) {
 	db := &DomainsDbStub{found: true, userId: 1, hostedZoneId: "1"}
 	dnsStub := &DnsStub{}
 	users := &DomainsUsersStub{authenticated: true, userId: 1}
-	domainService := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "2", &DetectorStub{})
+	domainService := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "2", &DetectorStub{}, "")
 	domains, err := domainService.GetDomains(&model.User{Id: 1})
 
 	assert.Nil(t, err)
@@ -407,7 +407,7 @@ func TestDomains_Update_Ipv6_Changed(t *testing.T) {
 	webLocalPort := 443
 	webProtocol := "https"
 	detector := &DetectorStub{changed: true}
-	domainService := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "2", detector)
+	domainService := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "2", detector, "")
 	domain, err := domainService.Update(model.DomainUpdateRequest{
 		MapLocalAddress: false,
 		WebLocalPort:    &webLocalPort,
@@ -434,7 +434,7 @@ func TestDomains_Update_LockedUser_Error(t *testing.T) {
 	webLocalPort := 443
 	webProtocol := "https"
 	detector := &DetectorStub{changed: true}
-	domainService := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "2", detector)
+	domainService := NewDomains(dnsStub, db, users, metrics.New(), "syncloud.it", "2", detector, "")
 	_, err := domainService.Update(model.DomainUpdateRequest{
 		MapLocalAddress: false,
 		WebLocalPort:    &webLocalPort,

--- a/backend/utils/config.go
+++ b/backend/utils/config.go
@@ -127,7 +127,7 @@ func (config *Config) GetRelayMonthlyLimitBytes() int64 {
 	if value, err := config.parser.GetInt64("relay", "monthly_limit_bytes"); err == nil {
 		return value
 	}
-	return 0
+	return 10 * 1024 * 1024 * 1024
 }
 
 func (config *Config) GetRelayPollIntervalSeconds() int {

--- a/backend/utils/config.go
+++ b/backend/utils/config.go
@@ -144,20 +144,6 @@ func (config *Config) GetFrpsMetricsUrl() string {
 	return "http://127.0.0.1:7500/metrics"
 }
 
-func (config *Config) GetFrpsAdminUser() string {
-	if value, err := config.parser.Get("relay", "frps_admin_user"); err == nil {
-		return value
-	}
-	return "admin"
-}
-
-func (config *Config) GetFrpsAdminPasswordFile() string {
-	if value, err := config.parser.Get("relay", "frps_admin_password_file"); err == nil {
-		return value
-	}
-	return "/var/www/redirect/frps.admin"
-}
-
 func (config *Config) AwsAccessKeyId() string {
 	value, err := config.parser.Get("aws", "access_key_id")
 	if err != nil {

--- a/backend/utils/config.go
+++ b/backend/utils/config.go
@@ -144,6 +144,13 @@ func (config *Config) GetFrpsMetricsUrl() string {
 	return "http://127.0.0.1:7500/metrics"
 }
 
+func (config *Config) GetRelayAddress() string {
+	if value, err := config.parser.Get("relay", "address"); err == nil {
+		return value
+	}
+	return ""
+}
+
 func (config *Config) AwsAccessKeyId() string {
 	value, err := config.parser.Get("aws", "access_key_id")
 	if err != nil {

--- a/backend/utils/config.go
+++ b/backend/utils/config.go
@@ -116,6 +116,13 @@ func (config *Config) GetWwwMetricsAddr() string {
 	return ":9092"
 }
 
+func (config *Config) GetRelayPluginAddr() string {
+	if value, err := config.parser.Get("relay", "plugin_addr"); err == nil {
+		return value
+	}
+	return "127.0.0.1:7501"
+}
+
 func (config *Config) AwsAccessKeyId() string {
 	value, err := config.parser.Get("aws", "access_key_id")
 	if err != nil {

--- a/backend/utils/config.go
+++ b/backend/utils/config.go
@@ -123,6 +123,41 @@ func (config *Config) GetRelayPluginAddr() string {
 	return "127.0.0.1:7501"
 }
 
+func (config *Config) GetRelayMonthlyLimitBytes() int64 {
+	if value, err := config.parser.GetInt64("relay", "monthly_limit_bytes"); err == nil {
+		return value
+	}
+	return 0
+}
+
+func (config *Config) GetRelayPollIntervalSeconds() int {
+	if value, err := config.parser.GetInt64("relay", "poll_interval_seconds"); err == nil {
+		return int(value)
+	}
+	return 60
+}
+
+func (config *Config) GetFrpsMetricsUrl() string {
+	if value, err := config.parser.Get("relay", "frps_metrics_url"); err == nil {
+		return value
+	}
+	return "http://127.0.0.1:7500/metrics"
+}
+
+func (config *Config) GetFrpsAdminUser() string {
+	if value, err := config.parser.Get("relay", "frps_admin_user"); err == nil {
+		return value
+	}
+	return "admin"
+}
+
+func (config *Config) GetFrpsAdminPasswordFile() string {
+	if value, err := config.parser.Get("relay", "frps_admin_password_file"); err == nil {
+		return value
+	}
+	return "/var/www/redirect/frps.admin"
+}
+
 func (config *Config) AwsAccessKeyId() string {
 	value, err := config.parser.Get("aws", "access_key_id")
 	if err != nil {

--- a/ci/deploy-verify.sh
+++ b/ci/deploy-verify.sh
@@ -63,3 +63,12 @@ if [ "$node_code" != "200" ]; then
     exit 1
 fi
 echo "node-exporter OK"
+
+frps_running=$($SSH $REMOTE "sudo -n docker ps -q --filter name=frps --filter status=running" || true)
+if [ -z "$frps_running" ]; then
+    echo "frps container is not running"
+    $SSH $REMOTE sudo -n docker ps -a --filter name=frps || true
+    $SSH $REMOTE sudo -n docker logs frps 2>&1 | tail -40 || true
+    exit 1
+fi
+echo "frps OK"

--- a/config/common/apache/redirect.conf
+++ b/config/common/apache/redirect.conf
@@ -25,7 +25,7 @@
 
 </VirtualHost>
 
-<VirtualHost *:443>
+<VirtualHost 127.0.0.1:8443>
 
     ServerName ${SYNCLOUD_DOMAIN}
     ServerAlias www.${SYNCLOUD_DOMAIN}
@@ -54,7 +54,7 @@
 
 </VirtualHost>
 
-<VirtualHost *:443>
+<VirtualHost 127.0.0.1:8443>
 
     ServerName api.${SYNCLOUD_DOMAIN}
     ServerAlias *.${SYNCLOUD_DOMAIN}

--- a/config/common/frp/frps.toml
+++ b/config/common/frp/frps.toml
@@ -10,9 +10,6 @@ webServer.password = "__FRPS_ADMIN_PASSWORD__"
 
 enablePrometheus = true
 
-auth.method = "token"
-auth.token = "__FRPS_TOKEN__"
-
 log.to = "console"
 log.level = "info"
 

--- a/config/common/frp/frps.toml
+++ b/config/common/frp/frps.toml
@@ -15,3 +15,9 @@ auth.token = "__FRPS_TOKEN__"
 
 log.to = "console"
 log.level = "info"
+
+[[httpPlugins]]
+name = "redirect-relay-auth"
+addr = "127.0.0.1:7501"
+path = "/plugin"
+ops = ["NewProxy"]

--- a/config/common/frp/frps.toml
+++ b/config/common/frp/frps.toml
@@ -1,0 +1,17 @@
+bindAddr = "127.0.0.1"
+bindPort = 7000
+proxyBindAddr = "127.0.0.1"
+vhostHTTPSPort = 4443
+
+webServer.addr = "127.0.0.1"
+webServer.port = 7500
+webServer.user = "admin"
+webServer.password = "__FRPS_ADMIN_PASSWORD__"
+
+enablePrometheus = true
+
+auth.method = "token"
+auth.token = "__FRPS_TOKEN__"
+
+log.to = "console"
+log.level = "info"

--- a/config/common/frp/frps.toml
+++ b/config/common/frp/frps.toml
@@ -5,8 +5,6 @@ vhostHTTPSPort = 4443
 
 webServer.addr = "127.0.0.1"
 webServer.port = 7500
-webServer.user = "admin"
-webServer.password = "__FRPS_ADMIN_PASSWORD__"
 
 enablePrometheus = true
 

--- a/config/common/frp/frps.toml
+++ b/config/common/frp/frps.toml
@@ -17,4 +17,4 @@ log.level = "info"
 name = "redirect-relay-auth"
 addr = "127.0.0.1:7501"
 path = "/plugin"
-ops = ["NewProxy"]
+ops = ["NewProxy", "NewUserConn"]

--- a/config/common/nginx/stream-relay.conf
+++ b/config/common/nginx/stream-relay.conf
@@ -1,0 +1,27 @@
+map $ssl_preread_server_name $syncloud_upstream {
+    www.__SYNCLOUD_DOMAIN__   apache_backend;
+    __SYNCLOUD_DOMAIN__       apache_backend;
+    api.__SYNCLOUD_DOMAIN__   apache_backend;
+    ""                        frps_control;
+    default                   frps_vhost;
+}
+
+upstream apache_backend {
+    server 127.0.0.1:8443;
+}
+
+upstream frps_vhost {
+    server 127.0.0.1:4443;
+}
+
+upstream frps_control {
+    server 127.0.0.1:7000;
+}
+
+server {
+    listen 443;
+    listen [::]:443;
+    ssl_preread on;
+    proxy_timeout 1h;
+    proxy_pass $syncloud_upstream;
+}

--- a/config/common/nginx/stream-relay.conf
+++ b/config/common/nginx/stream-relay.conf
@@ -2,7 +2,7 @@ map $ssl_preread_server_name $syncloud_upstream {
     www.__SYNCLOUD_DOMAIN__   apache_backend;
     __SYNCLOUD_DOMAIN__       apache_backend;
     api.__SYNCLOUD_DOMAIN__   apache_backend;
-    ""                        frps_control;
+    relay.__SYNCLOUD_DOMAIN__ frps_control;
     default                   frps_vhost;
 }
 

--- a/config/env/integration/config.cfg
+++ b/config/env/integration/config.cfg
@@ -40,3 +40,7 @@ www_addr = :9092
 
 [cleaner]
 user = false
+
+[relay]
+monthly_limit_bytes = 50000
+poll_interval_seconds = 1

--- a/config/env/integration/config.cfg
+++ b/config/env/integration/config.cfg
@@ -42,5 +42,6 @@ www_addr = :9092
 user = false
 
 [relay]
+address = 10.0.0.99
 monthly_limit_bytes = 50000
 poll_interval_seconds = 1

--- a/config/env/prod/config.cfg
+++ b/config/env/prod/config.cfg
@@ -45,3 +45,6 @@ www_addr = :9092
 
 [cleaner]
 user = true
+
+[relay]
+address = 54.70.47.240

--- a/config/env/uat/config.cfg
+++ b/config/env/uat/config.cfg
@@ -45,3 +45,6 @@ www_addr = :9092
 
 [cleaner]
 user = true
+
+[relay]
+address = 35.160.228.14

--- a/db/init.sql
+++ b/db/init.sql
@@ -17,6 +17,7 @@ CREATE TABLE `user` (
   `timestamp` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `premium_status_id` integer NOT NULL DEFAULT 1,
   `subscription_id` varchar(100) NULL,
+  `subscription_type` integer NULL,
   `registered_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   `status` integer DEFAULT 0,
   `status_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -70,4 +71,4 @@ create table db_version (
   `timestamp` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
-insert into db_version (version) values ('014');
+insert into db_version (version) values ('015');

--- a/db/update.sql
+++ b/db/update.sql
@@ -1,2 +1,16 @@
-alter table user add column `subscription_type` integer NULL;
+set @has_subscription_type := (select count(*) from information_schema.columns
+  where table_schema = database() and table_name = 'user' and column_name = 'subscription_type');
+set @stmt := if(@has_subscription_type = 0,
+  'alter table user add column `subscription_type` integer NULL', 'do 0');
+prepare add_subscription_type from @stmt;
+execute add_subscription_type;
+deallocate prepare add_subscription_type;
 insert into db_version (version) values ('015');
+
+create table if not exists relay_traffic (
+  `name` varchar(255) not null,
+  `year_month` char(7) not null,
+  `bytes` bigint not null default 0,
+  primary key (`name`, `year_month`)
+);
+insert into db_version (version) values ('016');

--- a/db/update.sql
+++ b/db/update.sql
@@ -1,13 +1,4 @@
-set @has_subscription_type := (select count(*) from information_schema.columns
-  where table_schema = database() and table_name = 'user' and column_name = 'subscription_type');
-set @stmt := if(@has_subscription_type = 0,
-  'alter table user add column `subscription_type` integer NULL', 'do 0');
-prepare add_subscription_type from @stmt;
-execute add_subscription_type;
-deallocate prepare add_subscription_type;
-insert into db_version (version) values ('015');
-
-create table if not exists relay_traffic (
+create table relay_traffic (
   `name` varchar(255) not null,
   `year_month` char(7) not null,
   `bytes` bigint not null default 0,

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -10,10 +10,13 @@ TAG=$1
 REDIRECT_DIR=/var/www/redirect
 STAGE=/tmp/syncloud-redirect
 
-PKGS="docker.io apache2 default-mysql-client python3"
+PKGS="docker.io apache2 nginx libnginx-mod-stream default-mysql-client python3 openssl"
 if ! dpkg -s $PKGS >/dev/null 2>&1; then
+    printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d
+    chmod +x /usr/sbin/policy-rc.d
     apt-get update
     apt-get install -y --no-install-recommends $PKGS
+    rm -f /usr/sbin/policy-rc.d
 fi
 
 if ! docker info >/dev/null 2>&1; then
@@ -70,10 +73,40 @@ install -m 0644 "$STAGE/common/apache/redirect.conf" /etc/apache2/sites-availabl
 if ! grep -q "^export SYNCLOUD_DOMAIN=" /etc/apache2/envvars; then
     echo "export SYNCLOUD_DOMAIN=$SYNCLOUD_DOMAIN" >> /etc/apache2/envvars
 fi
+
+cat > /etc/apache2/ports.conf <<'PORTS'
+Listen 80
+<IfModule ssl_module>
+    Listen 127.0.0.1:8443
+</IfModule>
+<IfModule mod_gnutls.c>
+    Listen 127.0.0.1:8443
+</IfModule>
+PORTS
+
 a2dissite 000-default 2>/dev/null || true
 a2ensite redirect
 a2enmod rewrite ssl proxy proxy_http
 systemctl restart apache2 2>/dev/null || apachectl restart
+
+rm -f /etc/nginx/sites-enabled/default
+install -d /etc/nginx/stream-enabled
+sed "s/__SYNCLOUD_DOMAIN__/$SYNCLOUD_DOMAIN/g" "$STAGE/common/nginx/stream-relay.conf" > /etc/nginx/stream-enabled/relay.conf
+if ! grep -q "stream-enabled" /etc/nginx/nginx.conf; then
+    printf '\nstream {\n    include /etc/nginx/stream-enabled/*.conf;\n}\n' >> /etc/nginx/nginx.conf
+fi
+nginx -t
+systemctl reload nginx 2>/dev/null || systemctl restart nginx 2>/dev/null || nginx
+
+FRPS_TOKEN_FILE="$REDIRECT_DIR/frps.token"
+FRPS_ADMIN_FILE="$REDIRECT_DIR/frps.admin"
+[ -f "$FRPS_TOKEN_FILE" ] || openssl rand -hex 32 > "$FRPS_TOKEN_FILE"
+[ -f "$FRPS_ADMIN_FILE" ] || openssl rand -hex 16 > "$FRPS_ADMIN_FILE"
+chmod 600 "$FRPS_TOKEN_FILE" "$FRPS_ADMIN_FILE"
+sed -e "s/__FRPS_TOKEN__/$(cat "$FRPS_TOKEN_FILE")/g" \
+    -e "s/__FRPS_ADMIN_PASSWORD__/$(cat "$FRPS_ADMIN_FILE")/g" \
+    "$STAGE/common/frp/frps.toml" > "$REDIRECT_DIR/frps.toml"
+chmod 600 "$REDIRECT_DIR/frps.toml"
 
 crontab -u redirect "$STAGE/common/cron/crontab"
 
@@ -112,6 +145,16 @@ run_container() {
 run_container redirect-api api
 run_container redirect-www www
 
+FRPS_IMAGE=snowdreamtech/frps:latest
+docker pull "$FRPS_IMAGE"
+docker rm -f frps 2>/dev/null || true
+docker run -d \
+    --name frps \
+    --restart=unless-stopped \
+    --network=host \
+    -v "$REDIRECT_DIR/frps.toml:/etc/frp/frps.toml:ro" \
+    "$FRPS_IMAGE"
+
 NODE_EXPORTER_IMAGE=prom/node-exporter:v1.8.2
 docker pull "$NODE_EXPORTER_IMAGE"
 docker rm -f node-exporter 2>/dev/null || true
@@ -124,7 +167,7 @@ docker run -d \
     "$NODE_EXPORTER_IMAGE" \
     --path.rootfs=/host
 
-for name in redirect-api redirect-www node-exporter; do
+for name in redirect-api redirect-www node-exporter frps; do
     for i in $(seq 1 30); do
         if docker ps -q --filter name="$name" --filter status=running | grep -q .; then
             break

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -98,13 +98,10 @@ fi
 nginx -t
 systemctl reload nginx 2>/dev/null || systemctl restart nginx 2>/dev/null || nginx
 
-FRPS_TOKEN_FILE="$REDIRECT_DIR/frps.token"
 FRPS_ADMIN_FILE="$REDIRECT_DIR/frps.admin"
-[ -f "$FRPS_TOKEN_FILE" ] || openssl rand -hex 32 > "$FRPS_TOKEN_FILE"
 [ -f "$FRPS_ADMIN_FILE" ] || openssl rand -hex 16 > "$FRPS_ADMIN_FILE"
-chmod 600 "$FRPS_TOKEN_FILE" "$FRPS_ADMIN_FILE"
-sed -e "s/__FRPS_TOKEN__/$(cat "$FRPS_TOKEN_FILE")/g" \
-    -e "s/__FRPS_ADMIN_PASSWORD__/$(cat "$FRPS_ADMIN_FILE")/g" \
+chmod 600 "$FRPS_ADMIN_FILE"
+sed -e "s/__FRPS_ADMIN_PASSWORD__/$(cat "$FRPS_ADMIN_FILE")/g" \
     "$STAGE/common/frp/frps.toml" > "$REDIRECT_DIR/frps.toml"
 chmod 600 "$REDIRECT_DIR/frps.toml"
 
@@ -145,7 +142,7 @@ run_container() {
 run_container redirect-api api
 run_container redirect-www www
 
-FRPS_IMAGE=snowdreamtech/frps:latest
+FRPS_IMAGE=snowdreamtech/frps:0.70.0-alpine
 docker pull "$FRPS_IMAGE"
 docker rm -f frps 2>/dev/null || true
 docker run -d \

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -98,12 +98,7 @@ fi
 nginx -t
 systemctl reload nginx 2>/dev/null || systemctl restart nginx 2>/dev/null || nginx
 
-FRPS_ADMIN_FILE="$REDIRECT_DIR/frps.admin"
-[ -f "$FRPS_ADMIN_FILE" ] || openssl rand -hex 16 > "$FRPS_ADMIN_FILE"
-chmod 600 "$FRPS_ADMIN_FILE"
-sed -e "s/__FRPS_ADMIN_PASSWORD__/$(cat "$FRPS_ADMIN_FILE")/g" \
-    "$STAGE/common/frp/frps.toml" > "$REDIRECT_DIR/frps.toml"
-chmod 600 "$REDIRECT_DIR/frps.toml"
+install -m 0644 "$STAGE/common/frp/frps.toml" "$REDIRECT_DIR/frps.toml"
 
 crontab -u redirect "$STAGE/common/cron/crontab"
 

--- a/integration/test.py
+++ b/integration/test.py
@@ -1,8 +1,18 @@
 import json
-from os.path import dirname
-
-import requests
+import os
+import ssl
+import subprocess
+import tarfile
+import tempfile
+import threading
 import time
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from os.path import dirname, join
+
+import pytest
+import requests
+from syncloudlib.integration.hosts import add_host_alias
 
 import smtp
 import api
@@ -856,3 +866,216 @@ def test_certbot_support(domain, artifact_dir):
                              },
                              verify=False)
     assert response.status_code == 200, response.text
+
+
+RELAY_ADDRESS = '10.0.0.99'
+FRP_VERSION = '0.70.0'
+BACKEND_BODY = 'relay-backend-ok'
+BACKEND_PORT = 18443
+BIG_BODY = ('x' * 65536).encode()
+
+
+@pytest.fixture(scope='session')
+def frpc():
+    url = 'https://github.com/fatedier/frp/releases/download/v{0}/frp_{0}_linux_amd64.tar.gz'.format(FRP_VERSION)
+    work = tempfile.mkdtemp()
+    tgz = join(work, 'frp.tgz')
+    error = None
+    for _ in range(5):
+        try:
+            urllib.request.urlretrieve(url, tgz)
+            error = None
+            break
+        except Exception as e:
+            error = e
+            time.sleep(3)
+    if error is not None:
+        raise error
+    with tarfile.open(tgz) as tar:
+        tar.extractall(work)
+    frpc_path = join(work, 'frp_{0}_linux_amd64'.format(FRP_VERSION), 'frpc')
+    os.chmod(frpc_path, 0o755)
+    return frpc_path
+
+
+class RelayBackendHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = BIG_BODY if self.path == '/big' else BACKEND_BODY.encode()
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/plain')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+def relay_gen_cert(work_dir):
+    cert = join(work_dir, 'backend.crt')
+    key = join(work_dir, 'backend.key')
+    subprocess.check_call([
+        'openssl', 'req', '-x509', '-newkey', 'rsa:2048',
+        '-keyout', key, '-out', cert, '-nodes', '-days', '1',
+        '-subj', '/CN=relay-backend'])
+    return cert, key
+
+
+def relay_start_backend(work_dir):
+    cert, key = relay_gen_cert(work_dir)
+    httpd = HTTPServer(('127.0.0.1', BACKEND_PORT), RelayBackendHandler)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(cert, key)
+    httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd
+
+
+def relay_write_frpc_config(path, server_addr, server_name, token, domain_name):
+    config = (
+        'serverAddr = "{addr}"\n'
+        'serverPort = 443\n'
+        'transport.tls.enable = true\n'
+        'transport.tls.serverName = "{sni}"\n'
+        'transport.tls.disableCustomTLSFirstByte = true\n'
+        'metadatas.token = "{token}"\n'
+        '\n'
+        '[[proxies]]\n'
+        'name = "{domain}"\n'
+        'type = "https"\n'
+        'customDomains = ["{domain}"]\n'
+        'localIP = "127.0.0.1"\n'
+        'localPort = {port}\n'
+    ).format(addr=server_addr, sni=server_name, token=token, domain=domain_name, port=BACKEND_PORT)
+    with open(path, 'w') as f:
+        f.write(config)
+
+
+def relay_start_frpc(frpc_path, work_dir, server_addr, server_name, token, domain_name, tag):
+    config_path = join(work_dir, 'frpc-{0}.toml'.format(tag))
+    log_path = join(work_dir, 'frpc-{0}.log'.format(tag))
+    relay_write_frpc_config(config_path, server_addr, server_name, token, domain_name)
+    log = open(log_path, 'w')
+    process = subprocess.Popen([frpc_path, '-c', config_path], stdout=log, stderr=subprocess.STDOUT)
+    return process, log_path
+
+
+def relay_fetch(domain_name):
+    return requests.get('https://{0}/'.format(domain_name), verify=False, timeout=5)
+
+
+def test_relay_valid_token_tunnels_traffic(domain, device_host, artifact_dir, frpc):
+    user_domain = 'relaye2e'
+    domain_name = '{0}.{1}'.format(user_domain, domain)
+    email = 'relay_e2e@syncloud.test'
+    password = 'pass123456'
+    create_user(domain, email, password, artifact_dir)
+    token = api.domain_acquire(domain, domain_name, email, password)
+    add_host_alias(user_domain, device_host, domain)
+
+    work_dir = tempfile.mkdtemp()
+    backend = relay_start_backend(work_dir)
+    process, log_path = relay_start_frpc(frpc, work_dir, device_host, 'relay.{0}'.format(domain), token, domain_name, 'valid')
+    try:
+        body = None
+        for _ in range(30):
+            try:
+                response = relay_fetch(domain_name)
+                if response.status_code == 200:
+                    body = response.text
+                    break
+            except Exception:
+                pass
+            time.sleep(2)
+        assert body == BACKEND_BODY, open(log_path).read()
+    finally:
+        process.terminate()
+        backend.shutdown()
+
+
+def test_relay_bad_token_rejected(domain, device_host, frpc):
+    user_domain = 'relayneg'
+    domain_name = '{0}.{1}'.format(user_domain, domain)
+    add_host_alias(user_domain, device_host, domain)
+
+    work_dir = tempfile.mkdtemp()
+    bad_token = '00000000-0000-0000-0000-000000000000'
+    process, log_path = relay_start_frpc(frpc, work_dir, device_host, 'relay.{0}'.format(domain), bad_token, domain_name, 'bad')
+    try:
+        time.sleep(10)
+        got_backend = False
+        try:
+            got_backend = relay_fetch(domain_name).text == BACKEND_BODY
+        except Exception:
+            got_backend = False
+        assert not got_backend, 'relay served traffic for a domain the token does not own'
+    finally:
+        process.terminate()
+
+
+def test_relay_update_points_dns_at_relay(domain, artifact_dir):
+    email = 'relay_dns@syncloud.test'
+    password = 'pass123456'
+    create_user(domain, email, password, artifact_dir)
+    domain_name = 'relaydns.{0}'.format(domain)
+    update_token = api.domain_acquire(domain, domain_name, email, password)
+
+    response = requests.post('https://api.{0}/domain/update'.format(domain), json={
+        'token': update_token,
+        'ipv4_enabled': True,
+        'relay': True,
+        'web_protocol': 'https',
+        'web_local_port': 443,
+    }, verify=False)
+    assert response.status_code == 200, response.text
+
+    data = get_domain(update_token, domain)
+    assert data['ip'] == RELAY_ADDRESS, data
+
+
+def test_relay_monthly_limit_blocks_traffic(domain, device_host, artifact_dir, frpc):
+    user_domain = 'relayquota'
+    domain_name = '{0}.{1}'.format(user_domain, domain)
+    email = 'relay_quota@syncloud.test'
+    password = 'pass123456'
+    create_user(domain, email, password, artifact_dir)
+    token = api.domain_acquire(domain, domain_name, email, password)
+    add_host_alias(user_domain, device_host, domain)
+
+    work_dir = tempfile.mkdtemp()
+    backend = relay_start_backend(work_dir)
+    process, log_path = relay_start_frpc(frpc, work_dir, device_host, 'relay.{0}'.format(domain), token, domain_name, 'quota')
+    try:
+        up = False
+        for _ in range(30):
+            try:
+                if relay_fetch(domain_name).status_code == 200:
+                    up = True
+                    break
+            except Exception:
+                pass
+            time.sleep(2)
+        assert up, open(log_path).read()
+
+        time.sleep(4)
+
+        for _ in range(5):
+            try:
+                requests.get('https://{0}/big'.format(domain_name), verify=False, timeout=5)
+            except Exception:
+                pass
+
+        blocked = False
+        for _ in range(20):
+            try:
+                if requests.get('https://{0}/big'.format(domain_name), verify=False, timeout=5).status_code != 200:
+                    blocked = True
+                    break
+            except Exception:
+                blocked = True
+                break
+            time.sleep(1)
+        assert blocked, 'relay kept serving after exceeding the monthly limit\n' + open(log_path).read()
+    finally:
+        process.terminate()
+        backend.shutdown()

--- a/integration/test_relay.py
+++ b/integration/test_relay.py
@@ -95,7 +95,7 @@ def test_relay_valid_token_tunnels_traffic(domain, device_host, artifact_dir):
     add_host_alias(user_domain, device_host, domain)
 
     work_dir = tempfile.mkdtemp()
-    start_backend(work_dir)
+    backend = start_backend(work_dir)
     process, log_path = start_frpc(work_dir, device_host, 'relay.{0}'.format(domain), token, domain_name, 'valid')
     try:
         body = None
@@ -111,6 +111,7 @@ def test_relay_valid_token_tunnels_traffic(domain, device_host, artifact_dir):
         assert body == BACKEND_BODY, open(log_path).read()
     finally:
         process.terminate()
+        backend.shutdown()
 
 
 def test_relay_bad_token_rejected(domain, device_host):
@@ -143,7 +144,7 @@ def test_relay_monthly_limit_blocks_traffic(domain, device_host, artifact_dir):
     add_host_alias(user_domain, device_host, domain)
 
     work_dir = tempfile.mkdtemp()
-    start_backend(work_dir)
+    backend = start_backend(work_dir)
     process, log_path = start_frpc(work_dir, device_host, 'relay.{0}'.format(domain), token, domain_name, 'quota')
     try:
         up = False
@@ -178,3 +179,4 @@ def test_relay_monthly_limit_blocks_traffic(domain, device_host, artifact_dir):
         assert blocked, 'relay kept serving after exceeding the monthly limit\n' + open(log_path).read()
     finally:
         process.terminate()
+        backend.shutdown()

--- a/integration/test_relay.py
+++ b/integration/test_relay.py
@@ -1,5 +1,6 @@
 import ssl
 import subprocess
+import tempfile
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -90,8 +91,9 @@ def test_relay_valid_token_tunnels_traffic(domain, device_host, artifact_dir):
     token = api.domain_acquire(domain, domain_name, email, password)
     add_host_alias(user_domain, device_host, domain)
 
-    start_backend(artifact_dir)
-    process, log_path = start_frpc(artifact_dir, device_host, 'relay.{0}'.format(domain), token, domain_name, 'valid')
+    work_dir = tempfile.mkdtemp()
+    start_backend(work_dir)
+    process, log_path = start_frpc(work_dir, device_host, 'relay.{0}'.format(domain), token, domain_name, 'valid')
     try:
         body = None
         for _ in range(30):
@@ -108,13 +110,14 @@ def test_relay_valid_token_tunnels_traffic(domain, device_host, artifact_dir):
         process.terminate()
 
 
-def test_relay_bad_token_rejected(domain, device_host, artifact_dir):
+def test_relay_bad_token_rejected(domain, device_host):
     user_domain = 'relayneg'
     domain_name = '{0}.{1}'.format(user_domain, domain)
     add_host_alias(user_domain, device_host, domain)
 
+    work_dir = tempfile.mkdtemp()
     bad_token = '00000000-0000-0000-0000-000000000000'
-    process, log_path = start_frpc(artifact_dir, device_host, 'relay.{0}'.format(domain), bad_token, domain_name, 'bad')
+    process, log_path = start_frpc(work_dir, device_host, 'relay.{0}'.format(domain), bad_token, domain_name, 'bad')
     try:
         time.sleep(10)
         got_backend = False

--- a/integration/test_relay.py
+++ b/integration/test_relay.py
@@ -10,6 +10,7 @@ import requests
 from syncloudlib.integration.hosts import add_host_alias
 
 import api
+from test import create_user
 
 BACKEND_BODY = 'relay-backend-ok'
 BACKEND_PORT = 18443
@@ -83,7 +84,10 @@ def fetch(domain_name):
 def test_relay_valid_token_tunnels_traffic(domain, device_host, artifact_dir):
     user_domain = 'relaye2e'
     domain_name = '{0}.{1}'.format(user_domain, domain)
-    token = api.domain_acquire(domain, domain_name, 'relay_e2e@syncloud.test', 'pass123456')
+    email = 'relay_e2e@syncloud.test'
+    password = 'pass123456'
+    create_user(domain, email, password, artifact_dir)
+    token = api.domain_acquire(domain, domain_name, email, password)
     add_host_alias(user_domain, device_host, domain)
 
     start_backend(artifact_dir)

--- a/integration/test_relay.py
+++ b/integration/test_relay.py
@@ -11,7 +11,9 @@ import requests
 from syncloudlib.integration.hosts import add_host_alias
 
 import api
-from test import create_user
+from test import create_user, get_domain
+
+RELAY_ADDRESS = '10.0.0.99'
 
 BACKEND_BODY = 'relay-backend-ok'
 BACKEND_PORT = 18443
@@ -132,6 +134,26 @@ def test_relay_bad_token_rejected(domain, device_host):
         assert not got_backend, 'relay served traffic for a domain the token does not own'
     finally:
         process.terminate()
+
+
+def test_relay_update_points_dns_at_relay(domain, artifact_dir):
+    email = 'relay_dns@syncloud.test'
+    password = 'pass123456'
+    create_user(domain, email, password, artifact_dir)
+    domain_name = 'relaydns.{0}'.format(domain)
+    update_token = api.domain_acquire(domain, domain_name, email, password)
+
+    response = requests.post('https://api.{0}/domain/update'.format(domain), json={
+        'token': update_token,
+        'ipv4_enabled': True,
+        'relay': True,
+        'web_protocol': 'https',
+        'web_local_port': 443,
+    }, verify=False)
+    assert response.status_code == 200, response.text
+
+    data = get_domain(update_token, domain)
+    assert data['ip'] == RELAY_ADDRESS, data
 
 
 def test_relay_monthly_limit_blocks_traffic(domain, device_host, artifact_dir):

--- a/integration/test_relay.py
+++ b/integration/test_relay.py
@@ -15,15 +15,18 @@ from test import create_user
 
 BACKEND_BODY = 'relay-backend-ok'
 BACKEND_PORT = 18443
+BIG_BODY = ('x' * 65536).encode()
 FRPC = environ.get('FRPC', '/usr/local/bin/frpc')
 
 
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
+        body = BIG_BODY if self.path == '/big' else BACKEND_BODY.encode()
         self.send_response(200)
         self.send_header('Content-Type', 'text/plain')
+        self.send_header('Content-Length', str(len(body)))
         self.end_headers()
-        self.wfile.write(BACKEND_BODY.encode())
+        self.wfile.write(body)
 
     def log_message(self, *args):
         pass
@@ -59,7 +62,7 @@ def write_frpc_config(path, server_addr, server_name, token, domain_name):
         'metadatas.token = "{token}"\n'
         '\n'
         '[[proxies]]\n'
-        'name = "relay-e2e"\n'
+        'name = "{domain}"\n'
         'type = "https"\n'
         'customDomains = ["{domain}"]\n'
         'localIP = "127.0.0.1"\n'
@@ -126,5 +129,52 @@ def test_relay_bad_token_rejected(domain, device_host):
         except Exception:
             got_backend = False
         assert not got_backend, 'relay served traffic for a domain the token does not own'
+    finally:
+        process.terminate()
+
+
+def test_relay_monthly_limit_blocks_traffic(domain, device_host, artifact_dir):
+    user_domain = 'relayquota'
+    domain_name = '{0}.{1}'.format(user_domain, domain)
+    email = 'relay_quota@syncloud.test'
+    password = 'pass123456'
+    create_user(domain, email, password, artifact_dir)
+    token = api.domain_acquire(domain, domain_name, email, password)
+    add_host_alias(user_domain, device_host, domain)
+
+    work_dir = tempfile.mkdtemp()
+    start_backend(work_dir)
+    process, log_path = start_frpc(work_dir, device_host, 'relay.{0}'.format(domain), token, domain_name, 'quota')
+    try:
+        up = False
+        for _ in range(30):
+            try:
+                if fetch(domain_name).status_code == 200:
+                    up = True
+                    break
+            except Exception:
+                pass
+            time.sleep(2)
+        assert up, open(log_path).read()
+
+        time.sleep(4)
+
+        for _ in range(5):
+            try:
+                requests.get('https://{0}/big'.format(domain_name), verify=False, timeout=5)
+            except Exception:
+                pass
+
+        blocked = False
+        for _ in range(20):
+            try:
+                if requests.get('https://{0}/big'.format(domain_name), verify=False, timeout=5).status_code != 200:
+                    blocked = True
+                    break
+            except Exception:
+                blocked = True
+                break
+            time.sleep(1)
+        assert blocked, 'relay kept serving after exceeding the monthly limit\n' + open(log_path).read()
     finally:
         process.terminate()

--- a/integration/test_relay.py
+++ b/integration/test_relay.py
@@ -1,0 +1,123 @@
+import ssl
+import subprocess
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from os import environ
+from os.path import join
+
+import requests
+from syncloudlib.integration.hosts import add_host_alias
+
+import api
+
+BACKEND_BODY = 'relay-backend-ok'
+BACKEND_PORT = 18443
+FRPC = environ.get('FRPC', '/usr/local/bin/frpc')
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/plain')
+        self.end_headers()
+        self.wfile.write(BACKEND_BODY.encode())
+
+    def log_message(self, *args):
+        pass
+
+
+def gen_cert(work_dir):
+    cert = join(work_dir, 'backend.crt')
+    key = join(work_dir, 'backend.key')
+    subprocess.check_call([
+        'openssl', 'req', '-x509', '-newkey', 'rsa:2048',
+        '-keyout', key, '-out', cert, '-nodes', '-days', '1',
+        '-subj', '/CN=relay-backend'])
+    return cert, key
+
+
+def start_backend(work_dir):
+    cert, key = gen_cert(work_dir)
+    httpd = HTTPServer(('127.0.0.1', BACKEND_PORT), Handler)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(cert, key)
+    httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd
+
+
+def write_frpc_config(path, server_addr, server_name, token, domain_name):
+    config = (
+        'serverAddr = "{addr}"\n'
+        'serverPort = 443\n'
+        'transport.tls.enable = true\n'
+        'transport.tls.serverName = "{sni}"\n'
+        'transport.tls.disableCustomTLSFirstByte = true\n'
+        'metadatas.token = "{token}"\n'
+        '\n'
+        '[[proxies]]\n'
+        'name = "relay-e2e"\n'
+        'type = "https"\n'
+        'customDomains = ["{domain}"]\n'
+        'localIP = "127.0.0.1"\n'
+        'localPort = {port}\n'
+    ).format(addr=server_addr, sni=server_name, token=token, domain=domain_name, port=BACKEND_PORT)
+    with open(path, 'w') as f:
+        f.write(config)
+
+
+def start_frpc(work_dir, server_addr, server_name, token, domain_name, tag):
+    config_path = join(work_dir, 'frpc-{0}.toml'.format(tag))
+    log_path = join(work_dir, 'frpc-{0}.log'.format(tag))
+    write_frpc_config(config_path, server_addr, server_name, token, domain_name)
+    log = open(log_path, 'w')
+    process = subprocess.Popen([FRPC, '-c', config_path], stdout=log, stderr=subprocess.STDOUT)
+    return process, log_path
+
+
+def fetch(domain_name):
+    return requests.get('https://{0}/'.format(domain_name), verify=False, timeout=5)
+
+
+def test_relay_valid_token_tunnels_traffic(domain, device_host, artifact_dir):
+    user_domain = 'relaye2e'
+    domain_name = '{0}.{1}'.format(user_domain, domain)
+    token = api.domain_acquire(domain, domain_name, 'relay_e2e@syncloud.test', 'pass123456')
+    add_host_alias(user_domain, device_host, domain)
+
+    start_backend(artifact_dir)
+    process, log_path = start_frpc(artifact_dir, device_host, 'relay.{0}'.format(domain), token, domain_name, 'valid')
+    try:
+        body = None
+        for _ in range(30):
+            try:
+                response = fetch(domain_name)
+                if response.status_code == 200:
+                    body = response.text
+                    break
+            except Exception:
+                pass
+            time.sleep(2)
+        assert body == BACKEND_BODY, open(log_path).read()
+    finally:
+        process.terminate()
+
+
+def test_relay_bad_token_rejected(domain, device_host, artifact_dir):
+    user_domain = 'relayneg'
+    domain_name = '{0}.{1}'.format(user_domain, domain)
+    add_host_alias(user_domain, device_host, domain)
+
+    bad_token = '00000000-0000-0000-0000-000000000000'
+    process, log_path = start_frpc(artifact_dir, device_host, 'relay.{0}'.format(domain), bad_token, domain_name, 'bad')
+    try:
+        time.sleep(10)
+        got_backend = False
+        try:
+            got_backend = fetch(domain_name).text == BACKEND_BODY
+        except Exception:
+            got_backend = False
+        assert not got_backend, 'relay served traffic for a domain the token does not own'
+    finally:
+        process.terminate()

--- a/monitoring/grafana/redirect-v2.json
+++ b/monitoring/grafana/redirect-v2.json
@@ -10,12 +10,17 @@
     }
   ],
   "title": "Redirect v2",
-  "tags": ["redirect"],
+  "tags": [
+    "redirect"
+  ],
   "timezone": "browser",
   "schemaVersion": 39,
   "version": 1,
   "refresh": "30s",
-  "time": { "from": "now-30d", "to": "now" },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
   "templating": {
     "list": [
       {
@@ -23,10 +28,21 @@
         "label": "env",
         "type": "custom",
         "query": "uat,prod",
-        "current": { "text": "uat", "value": "uat" },
+        "current": {
+          "text": "uat",
+          "value": "uat"
+        },
         "options": [
-          { "text": "uat", "value": "uat", "selected": true },
-          { "text": "prod", "value": "prod", "selected": false }
+          {
+            "text": "uat",
+            "value": "uat",
+            "selected": true
+          },
+          {
+            "text": "prod",
+            "value": "prod",
+            "selected": false
+          }
         ]
       }
     ]
@@ -36,8 +52,16 @@
       "type": "timeseries",
       "title": "Users by state ($env)",
       "id": 1,
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
       "targets": [
         {
           "expr": "redirect_db_users{env=\"$env\"}",
@@ -46,15 +70,26 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "short", "min": 0 }
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        }
       }
     },
     {
       "type": "timeseries",
       "title": "Devices online ($env)",
       "id": 2,
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
       "targets": [
         {
           "expr": "redirect_db_devices{env=\"$env\"}",
@@ -63,15 +98,26 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "short", "min": 0 }
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        }
       }
     },
     {
       "type": "timeseries",
       "title": "Domains total ($env)",
       "id": 3,
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
       "targets": [
         {
           "expr": "redirect_db_domains{env=\"$env\"}",
@@ -80,15 +126,26 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "short", "min": 0 }
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        }
       }
     },
     {
       "type": "timeseries",
       "title": "Request rate by handler ($env)",
       "id": 4,
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
       "targets": [
         {
           "expr": "sum(rate(redirect_requests_total{env=\"$env\"}[5m])) by (handler)",
@@ -97,15 +154,26 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "reqps", "min": 0 }
+        "defaults": {
+          "unit": "reqps",
+          "min": 0
+        }
       }
     },
     {
       "type": "timeseries",
       "title": "DNS client actions ($env)",
       "id": 5,
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
       "targets": [
         {
           "expr": "sum(rate(redirect_dns_client_actions_total{env=\"$env\"}[5m])) by (action)",
@@ -114,15 +182,26 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "ops", "min": 0 }
+        "defaults": {
+          "unit": "ops",
+          "min": 0
+        }
       }
     },
     {
       "type": "timeseries",
       "title": "Cleaner actions ($env)",
       "id": 6,
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
       "targets": [
         {
           "expr": "sum(rate(redirect_cleaner_actions_total{env=\"$env\"}[5m])) by (result)",
@@ -131,15 +210,26 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "ops", "min": 0 }
+        "defaults": {
+          "unit": "ops",
+          "min": 0
+        }
       }
     },
     {
       "type": "timeseries",
       "title": "CPU % by mode ($env)",
       "id": 7,
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
       "targets": [
         {
           "expr": "100 * sum(rate(node_cpu_seconds_total{env=\"$env\",mode!=\"idle\"}[5m])) by (mode) / scalar(sum(rate(node_cpu_seconds_total{env=\"$env\"}[5m])))",
@@ -148,15 +238,26 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "percent", "min": 0 }
+        "defaults": {
+          "unit": "percent",
+          "min": 0
+        }
       }
     },
     {
       "type": "timeseries",
       "title": "Memory ($env)",
       "id": 8,
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
       "targets": [
         {
           "expr": "node_memory_MemTotal_bytes{env=\"$env\"} - node_memory_MemAvailable_bytes{env=\"$env\"}",
@@ -170,15 +271,26 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "bytes", "min": 0 }
+        "defaults": {
+          "unit": "bytes",
+          "min": 0
+        }
       }
     },
     {
       "type": "timeseries",
       "title": "Disk I/O ($env)",
       "id": 9,
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
       "targets": [
         {
           "expr": "sum(rate(node_disk_read_bytes_total{env=\"$env\"}[5m])) by (device)",
@@ -192,15 +304,26 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "Bps", "min": 0 }
+        "defaults": {
+          "unit": "Bps",
+          "min": 0
+        }
       }
     },
     {
       "type": "timeseries",
       "title": "Network ($env)",
       "id": 10,
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
       "targets": [
         {
           "expr": "sum(rate(node_network_receive_bytes_total{env=\"$env\",device!~\"lo|docker.*|veth.*\"}[5m])) by (device)",
@@ -214,15 +337,26 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "Bps", "min": 0 }
+        "defaults": {
+          "unit": "Bps",
+          "min": 0
+        }
       }
     },
     {
       "type": "timeseries",
       "title": "Rogue devices by platform_version, 24h window ($env)",
       "id": 11,
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
       "targets": [
         {
           "expr": "label_replace(redirect_rogue_devices{env=\"$env\"}, \"platform_version\", \"unknown\", \"platform_version\", \"\")",
@@ -236,7 +370,10 @@
           "min": 0,
           "custom": {
             "drawStyle": "bars",
-            "stacking": { "mode": "normal", "group": "A" },
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
             "fillOpacity": 100,
             "lineWidth": 0,
             "barAlignment": 0
@@ -248,8 +385,16 @@
       "type": "timeseries",
       "title": "Active devices by platform_version, 1h window ($env)",
       "id": 12,
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
       "targets": [
         {
           "expr": "redirect_active_devices{env=\"$env\"}",
@@ -263,12 +408,44 @@
           "min": 0,
           "custom": {
             "drawStyle": "bars",
-            "stacking": { "mode": "normal", "group": "A" },
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
             "fillOpacity": 100,
             "lineWidth": 0,
             "barAlignment": 0
           }
         }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Relay traffic per user (this month)",
+      "id": 13,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "targets": [
+        {
+          "expr": "redirect_relay_traffic_bytes{env=\"$env\"}",
+          "legendFormat": "{{proxy}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "min": 0
+        },
+        "overrides": []
       }
     }
   ]


### PR DESCRIPTION
## What

First of three PRs adding **relay support for devices with no public IP (CGNAT)**.

This slice only builds the **single-443 front door + relay process**. No per-user auth, no clients, no billing yet — it is safe to deploy because it changes how the redirect host answers :443 without adding any user-facing behaviour.

## Why this design

Managed Syncloud domains already get their TLS cert via **DNS-01**, so the home box holds a valid public wildcard cert. The relay therefore never needs to terminate TLS — it reads the SNI name and passes the encrypted bytes straight through to the home box (zero-knowledge, and it keeps us inside "mere conduit" liability terms). Everything the relay needs — per-domain `update_token`, Route 53 DNS, accounts, Stripe/PayPal — already exists in redirect.

## Changes

- **nginx `stream` + `ssl_preread` owns :443** and routes by SNI:
  - `www` / `api` / apex → Apache (moved to `127.0.0.1:8443`, still terminating its own LE cert)
  - empty SNI → frps control
  - everything else (device subdomains) → frps HTTPS vhost
- **Apache no longer binds :443** (ports.conf → `127.0.0.1:8443`); :80 unchanged (http→https + ACME).
- **frps** container (`snowdreamtech/frps`), control `127.0.0.1:7000`, HTTPS vhost `127.0.0.1:4443`, admin+prometheus `127.0.0.1:7500`; token/admin password generated and persisted under `$REDIRECT_DIR`.
- `policy-rc.d` guard so nginx doesn't fight Apache for :80 during `apt install`.
- `deploy-verify.sh` gains an frps container check; existing www/api/status curls now transit nginx and guard the demux.

## Single public port

Everything stays on **:443** — no new security-group / firewall rule. The frpc control channel (PR 2) reaches frps via SNI through the same nginx demux.

## Validation

Auto-deploys UAT on push. Guard rails: `deploy-verify` fails the build if www, api `/status`, the DB smoke, node-exporter, or frps is unhealthy. Nothing here can register a tunnel yet, so the blast radius is limited to the :443 front-door refactor.

## Follow-ups

- **PR 2** — frpc on the device, `NewProxy` server-plugin validating `update_token` against redirect, `relay_id` schema + relay-mode activation, republish frps per-user traffic on redirect's already-scraped `:9091`, **Grafana per-user traffic panel**.
- **PR 3** — monthly per-user traffic quota (fair-use marker + tunnel kill switch).

## Notes for review

- `snowdreamtech/frps:latest` is intentionally unpinned for the first UAT bring-up; pin to a digest once we confirm the version that deploys cleanly.
- Prometheus scrape config lives out-of-band, which is why per-user traffic is republished through redirect's own metrics port in PR 2 rather than adding a scrape target here.