### PR TITLE
caddy: split vhosts into conf.d (step 1 of per-repo vhost ownership)

### DIFF
--- a/config/common/caddy/Caddyfile
+++ b/config/common/caddy/Caddyfile
@@ -3,11 +3,15 @@
 	acme_ca {$ACME_CA}
 }
 
-www.{$REDIRECT_DOMAIN} {
+(syncloud_tls) {
 	tls {
 		dns route53
 		resolvers {$DNS_RESOLVER}
 	}
+}
+
+www.{$REDIRECT_DOMAIN} {
+	import syncloud_tls
 	handle_path /api/* {
 		reverse_proxy unix//var/www/redirect/redirect.www.socket
 	}
@@ -19,34 +23,17 @@ www.{$REDIRECT_DOMAIN} {
 }
 
 {$REDIRECT_DOMAIN} {
-	tls {
-		dns route53
-		resolvers {$DNS_RESOLVER}
-	}
+	import syncloud_tls
 	redir https://www.{$REDIRECT_DOMAIN}{uri}
 }
 
 api.{$REDIRECT_DOMAIN} {
-	tls {
-		dns route53
-		resolvers {$DNS_RESOLVER}
-	}
+	import syncloud_tls
 	reverse_proxy unix//var/www/redirect/redirect.api.socket
 }
 
-{$STORE_DOMAIN}, {$STORE_API_DOMAIN} {
-	tls {
-		dns route53
-		resolvers {$DNS_RESOLVER}
-	}
-	reverse_proxy unix//var/www/store/api.socket
-}
-
 {$SHOP_DOMAIN} {
-	tls {
-		dns route53
-		resolvers {$DNS_RESOLVER}
-	}
+	import syncloud_tls
 	root * /var/www/shop/opencart
 
 	@denied path_regexp \.(tpl|twig|ini|log)$
@@ -73,20 +60,9 @@ api.{$REDIRECT_DOMAIN} {
 	file_server
 }
 
-{$SITE_DOMAIN} {
-	tls {
-		dns route53
-		resolvers {$DNS_RESOLVER}
-	}
-	root * /var/www/syncloud.org/current
-	try_files {path} /index.html
-	file_server
-}
-
 {$GRAFANA_DOMAIN} {
-	tls {
-		dns route53
-		resolvers {$DNS_RESOLVER}
-	}
+	import syncloud_tls
 	reverse_proxy localhost:3000
 }
+
+import /etc/caddy/conf.d/*.caddy

--- a/config/common/caddy/conf.d/store.caddy
+++ b/config/common/caddy/conf.d/store.caddy
@@ -1,0 +1,4 @@
+{$STORE_DOMAIN}, {$STORE_API_DOMAIN} {
+	import syncloud_tls
+	reverse_proxy unix//var/www/store/api.socket
+}

--- a/config/common/caddy/conf.d/syncloud.org.caddy
+++ b/config/common/caddy/conf.d/syncloud.org.caddy
@@ -1,0 +1,6 @@
+{$SITE_DOMAIN} {
+	import syncloud_tls
+	root * /var/www/syncloud.org/current
+	try_files {path} /index.html
+	file_server
+}

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -91,8 +91,11 @@ if [ -n "$POOL" ]; then
         || systemctl restart 'php*-fpm.service' 2>/dev/null || true
 fi
 
-install -d /etc/caddy
+install -d /etc/caddy /etc/caddy/conf.d
 install -m 0644 "$STAGE/common/caddy/Caddyfile" /etc/caddy/Caddyfile
+for f in "$STAGE"/common/caddy/conf.d/*.caddy; do
+    [ -e "$f" ] && install -m 0644 "$f" /etc/caddy/conf.d/
+done
 
 . "$STAGE/common/caddy/env/$SYNCLOUD_DOMAIN.env"
 


### PR DESCRIPTION
## What
Step 1 of moving the store and syncloud.org vhosts out of the monolithic Caddyfile and into per-repo ownership, using an Apache-`conf.d`-style layout.

- Main `Caddyfile`: redirect's own vhosts (www/api/apex.syncloud.it, shop, grafana) + a shared `(syncloud_tls)` snippet + `import /etc/caddy/conf.d/*.caddy`.
- `conf.d/store.caddy`, `conf.d/syncloud.org.caddy`: the store and site vhosts, shipped by redirect **for now** (identical to what those repos will own in step 2).
- `deploy.sh`: creates `/etc/caddy/conf.d` and installs snippets **additively** (loops over shipped files; never `rm -rf`s the dir), so once store/syncloud.org own their copies, dropping them here won't delete them.

## Why
So store and syncloud.org can eventually own **and test** their own vhost in their own CI (impossible while it lives here). This is the expand step of an expand/contract migration:

1. **[this PR]** redirect ships all snippets in `conf.d`.
2. store & syncloud.org ship + CI-test their own snippet, `deploy` drops it into `conf.d` and reloads Caddy (overwrites in place — identical content, no gap).
3. redirect stops shipping those two snippets (their copies persist on the host mount).

Vhosts served are **unchanged at every step**.

## Verified
`caddy validate` against the real `syncloud/caddy` image passes, and `caddy adapt` shows the exact same 8 site addresses as today (www/apex/api.syncloud.it, shop, stats.syncloud.it, store + api.store.syncloud.org, syncloud.org).

Functionally a no-op on prod — safe to deploy and verify before touching the other two repos.