### PR TITLE
caddy: stop shipping store/syncloud.org snippets (step 3, contract)

### DIFF
--- a/config/common/caddy/conf.d/store.caddy
+++ b/config/common/caddy/conf.d/store.caddy
@@ -1,4 +1,0 @@
-{$STORE_DOMAIN}, {$STORE_API_DOMAIN} {
-	import syncloud_tls
-	reverse_proxy unix//var/www/store/api.socket
-}

--- a/config/common/caddy/conf.d/syncloud.org.caddy
+++ b/config/common/caddy/conf.d/syncloud.org.caddy
@@ -1,6 +1,0 @@
-{$SITE_DOMAIN} {
-	import syncloud_tls
-	root * /var/www/syncloud.org/current
-	try_files {path} /index.html
-	file_server
-}


### PR DESCRIPTION
Final step of the per-repo vhost ownership split. store and syncloud.org now own, deploy, and reload their own `conf.d` snippets (shipped from their repos), so redirect stops shipping `conf.d/store.caddy` and `conf.d/syncloud.org.caddy`.

Safe because `deploy.sh` installs `conf.d` **additively** (loops over shipped files, never `rm -rf`s the dir) — the app-owned copies already on the box persist across redirect deploys. redirect keeps passing `STORE_DOMAIN`/`STORE_API_DOMAIN`/`SITE_DOMAIN` env, since the app snippets (loaded via `import conf.d/*.caddy`) reference them and redirect's Caddy is what runs.

Verified already: store.syncloud.org, api.store.syncloud.org, syncloud.org, www.syncloud.org all serve on prod from the app-owned snippets.