### PR TITLE
domains: reserve infra/main-site subdomain labels

### DIFF
--- a/backend/validation/validator.go
+++ b/backend/validation/validator.go
@@ -9,6 +9,23 @@ import (
 	"strings"
 )
 
+var reservedSubDomains = map[string]bool{
+	"relay": true,
+	"www":   true,
+	"api":   true,
+	"store": true,
+	"stats": true,
+	"shop":  true,
+	"mail":  true,
+	"mx":    true,
+	"smtp":  true,
+	"imap":  true,
+	"ns":    true,
+	"ns1":   true,
+	"ns2":   true,
+	"admin": true,
+}
+
 type FieldValidator struct {
 	errors       []string
 	fieldsErrors map[string][]string
@@ -52,6 +69,9 @@ func (v *FieldValidator) Domain(domain *string, field string, mainDomain string)
 				subDomain := parts[0]
 				if strings.Contains(subDomain, "_") {
 					v.addFieldError(field, "Cannot contain underscores '_'")
+				}
+				if reservedSubDomains[strings.ToLower(subDomain)] {
+					v.addFieldError(field, "Reserved name")
 				}
 				var valid = regexp.MustCompile(`^[\w-]+$`)
 				if !valid.MatchString(subDomain) {

--- a/backend/validation/validator_test.go
+++ b/backend/validation/validator_test.go
@@ -54,6 +54,15 @@ func TestFreeDomainLong(t *testing.T) {
 	assert.Equal(t, 1, len(validator.errors))
 }
 
+func TestFreeDomainReserved(t *testing.T) {
+	for _, name := range []string{"relay", "store", "stats", "admin", "RELAY"} {
+		domain := name + ".syncloud.it"
+		validator := New()
+		validator.Domain(&domain, "", "syncloud.it")
+		assert.Equal(t, 1, len(validator.errors), "expected %s to be reserved", name)
+	}
+}
+
 func TestFreeDomainEmpty(t *testing.T) {
 	domain := ".syncloud.it"
 	validator := New()


### PR DESCRIPTION
Blocks acquiring free subdomains whose first label is reserved (relay, www, api, store, stats, shop, mail, mx, smtp, imap, ns, ns1, ns2, admin). Prevents hijacking the relay control endpoint and main sites. Verified no such names are currently registered on prod.