### PR TITLE
db: fold migrations 016-017 into init.sql, empty update.sql

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -18,6 +18,7 @@ CREATE TABLE `user` (
   `premium_status_id` integer NOT NULL DEFAULT 1,
   `subscription_id` varchar(100) NULL,
   `subscription_type` integer NULL,
+  `plan` varchar(16) NULL,
   `registered_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   `status` integer DEFAULT 0,
   `status_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -66,9 +67,16 @@ CREATE TABLE `action` (
 insert into action_type (id, name) values (1, 'activate');
 insert into action_type (id, name) values (2, 'password');
 
+create table relay_traffic (
+  `name` varchar(255) not null,
+  `year_month` char(7) not null,
+  `bytes` bigint not null default 0,
+  primary key (`name`, `year_month`)
+);
+
 create table db_version (
   `version` varchar(10) not null,
   `timestamp` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
-insert into db_version (version) values ('015');
+insert into db_version (version) values ('017');

--- a/db/update.sql
+++ b/db/update.sql
@@ -1,10 +1,2 @@
-create table if not exists relay_traffic (
-  `name` varchar(255) not null,
-  `year_month` char(7) not null,
-  `bytes` bigint not null default 0,
-  primary key (`name`, `year_month`)
-);
-insert into db_version (version) values ('016');
-
-alter table user add column plan varchar(16) null;
-insert into db_version (version) values ('017');
+-- Schema through version 017 is created by init.sql, so there are no pending
+-- migrations. Add future deltas below, bumping the version at the end.


### PR DESCRIPTION
Fixes wedged prod deploys (same-timestamp version ambiguity re-ran the non-idempotent alter). init.sql now creates the full 017 schema; update.sql empty so existing boxes skip migration.