### PR TITLE
Reserve mail-relay subdomain

### DIFF
--- a/backend/validation/validator.go
+++ b/backend/validation/validator.go
@@ -10,20 +10,21 @@ import (
 )
 
 var reservedSubDomains = map[string]bool{
-	"relay": true,
-	"www":   true,
-	"api":   true,
-	"store": true,
-	"stats": true,
-	"shop":  true,
-	"mail":  true,
-	"mx":    true,
-	"smtp":  true,
-	"imap":  true,
-	"ns":    true,
-	"ns1":   true,
-	"ns2":   true,
-	"admin": true,
+	"relay":      true,
+	"mail-relay": true,
+	"www":        true,
+	"api":        true,
+	"store":      true,
+	"stats":      true,
+	"shop":       true,
+	"mail":       true,
+	"mx":         true,
+	"smtp":       true,
+	"imap":       true,
+	"ns":         true,
+	"ns1":        true,
+	"ns2":        true,
+	"admin":      true,
 }
 
 type FieldValidator struct {

--- a/backend/validation/validator_test.go
+++ b/backend/validation/validator_test.go
@@ -55,7 +55,7 @@ func TestFreeDomainLong(t *testing.T) {
 }
 
 func TestFreeDomainReserved(t *testing.T) {
-	for _, name := range []string{"relay", "store", "stats", "admin", "RELAY"} {
+	for _, name := range []string{"relay", "mail-relay", "store", "stats", "admin", "RELAY", "Mail-Relay"} {
 		domain := name + ".syncloud.it"
 		validator := New()
 		validator.Domain(&domain, "", "syncloud.it")


### PR DESCRIPTION
Devices reach the outbound relay at `mail-relay.<main domain>` (`platform backend/rest/api.go:167`). That name was not in `reservedSubDomains` — it held `relay`, `mail` and `smtp`, but not the hyphenated name actually in use.

Nothing stopped a user registering it: the subdomain regex is `^[\w-]+$` so hyphens are allowed, and `mail-relay` is 10 characters so it clears the 5-character minimum. On registration redirect UPSERTs the A record, which would repoint `mail-relay.syncloud.it` at the registering user's address — the endpoint devices authenticate to with their `domain_update_token`.

No existing domain matches `%relay%` or `%mail%` in prod, so nothing is squatting on it today.

Matching by exact lowercased label, so `Mail-Relay` is covered too; both cases are in the test.