### PR TITLE
Return 535 for permanent relay auth failures, fix password reset flake

### DIFF
--- a/backend/mailrelay/server.go
+++ b/backend/mailrelay/server.go
@@ -69,6 +69,14 @@ func permanent(err error, code smtp.EnhancedCode) error {
 	return &smtp.SMTPError{Code: 550, EnhancedCode: code, Message: err.Error()}
 }
 
+func authRejected(err error) error {
+	return &smtp.SMTPError{Code: 535, EnhancedCode: smtp.EnhancedCode{5, 7, 8}, Message: err.Error()}
+}
+
+func authTryAgain(err error) error {
+	return &smtp.SMTPError{Code: 454, EnhancedCode: smtp.EnhancedCode{4, 7, 0}, Message: err.Error()}
+}
+
 func peerOf(c *smtp.Conn) string {
 	if c == nil || c.Conn() == nil {
 		return ""

--- a/backend/mailrelay/server_test.go
+++ b/backend/mailrelay/server_test.go
@@ -36,17 +36,26 @@ type relayUnderTest struct {
 	scanner *fakeScanner
 }
 
-func startRelay(t *testing.T, limits Limits, sender *fakeSender, scanner *fakeScanner,
-	connections *Connections, inFlight *InFlight) *relayUnderTest {
-	t.Helper()
+func defaultRelay() *Relay {
 	token := "the-token"
-	relay := New(
+	return New(
 		&fakeDomains{domain: &model.Domain{Name: "device.syncloud.it", UserId: 7, UpdateToken: &token}},
 		&fakePlans{limit: 100},
 		&fakeUsage{},
 		&fakeBlocklist{},
 		&fakeWarner{},
 		zap.NewNop())
+}
+
+func startRelay(t *testing.T, limits Limits, sender *fakeSender, scanner *fakeScanner,
+	connections *Connections, inFlight *InFlight) *relayUnderTest {
+	t.Helper()
+	return startRelayWith(t, defaultRelay(), limits, sender, scanner, connections, inFlight)
+}
+
+func startRelayWith(t *testing.T, relay *Relay, limits Limits, sender *fakeSender, scanner *fakeScanner,
+	connections *Connections, inFlight *InFlight) *relayUnderTest {
+	t.Helper()
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.NoError(t, err)
@@ -125,13 +134,43 @@ func TestRelayServer_DeliversAuthenticatedMail(t *testing.T) {
 	assert.Equal(t, 1, sender.sent)
 }
 
-func TestRelayServer_RejectsWrongPassword(t *testing.T) {
-	r := relayFor(t, &fakeSender{}, &fakeScanner{})
+func authWith(t *testing.T, r *relayUnderTest, login string, password string) error {
+	t.Helper()
 	client, err := dial(t, r)
 	assert.NoError(t, err)
 	defer client.Close()
-	err = client.Auth(smtp.PlainAuth("", "device.syncloud.it", "wrong", "127.0.0.1"))
-	assert.Error(t, err)
+	return client.Auth(smtp.PlainAuth("", login, password, "127.0.0.1"))
+}
+
+func serverFor(t *testing.T, relay *Relay) *relayUnderTest {
+	t.Helper()
+	return startRelayWith(t, relay, defaultLimits(), &fakeSender{}, &fakeScanner{},
+		NewConnections(0), NewInFlight(0))
+}
+
+func TestRelayServer_RejectsWrongPassword(t *testing.T) {
+	r := relayFor(t, &fakeSender{}, &fakeScanner{})
+	assertCode(t, authWith(t, r, "device.syncloud.it", "wrong"), "535")
+}
+
+func TestRelayServer_RejectsForeignLogin(t *testing.T) {
+	r := relayFor(t, &fakeSender{}, &fakeScanner{})
+	assertCode(t, authWith(t, r, "someone-else.syncloud.it", "the-token"), "535")
+}
+
+func TestRelayServer_BlockedIsPermanent(t *testing.T) {
+	relay, _ := relayWith(100, 0, true)
+	assertCode(t, authWith(t, serverFor(t, relay), "device.syncloud.it", "the-token"), "535")
+}
+
+func TestRelayServer_PlanWithoutRelayIsPermanent(t *testing.T) {
+	relay, _ := relayWith(0, 0, false)
+	assertCode(t, authWith(t, serverFor(t, relay), "device.syncloud.it", "the-token"), "535")
+}
+
+func TestRelayServer_OverMonthlyLimitIsTemporary(t *testing.T) {
+	relay, _ := relayWith(10, 10, false)
+	assertCode(t, authWith(t, serverFor(t, relay), "device.syncloud.it", "the-token"), "454")
 }
 
 func TestRelayServer_RejectsForeignSender(t *testing.T) {

--- a/backend/mailrelay/session.go
+++ b/backend/mailrelay/session.go
@@ -33,11 +33,23 @@ func (s *Session) Auth(_ string) (sasl.Server, error) {
 		domain, err := s.relay.Authorize(login, password)
 		if err != nil {
 			s.logger.Info("mail relay auth rejected", zap.String("login", login), zap.Error(err))
-			return err
+			return authError(err)
 		}
 		s.domain = domain
 		return nil
 	}), nil
+}
+
+func authError(err error) error {
+	switch {
+	case errors.Is(err, ErrUnknownToken), errors.Is(err, ErrNotOwned),
+		errors.Is(err, ErrBlocked), errors.Is(err, ErrNotAllowed):
+		return authRejected(err)
+	case errors.Is(err, ErrOverLimit):
+		return authTryAgain(err)
+	default:
+		return authTryAgain(errors.New("temporary authentication failure"))
+	}
 }
 
 func (s *Session) Mail(from string, _ *smtp.MailOptions) error {

--- a/web/e2e/password-reset.spec.js
+++ b/web/e2e/password-reset.spec.js
@@ -2,6 +2,13 @@ const { test, expect } = require('./fixtures')
 const { waitForResetUrl } = require('./helpers/mailhog')
 const { registerActivateAndLogin } = require('./helpers/user')
 
+async function fillStable (locator, value) {
+  await expect(async () => {
+    await locator.fill(value)
+    await expect(locator).toHaveValue(value)
+  }).toPass()
+}
+
 test('user can reset password and log in with the new password', async ({ page }) => {
   const originalPassword = 'password123'
   const { email } = await registerActivateAndLogin(page, 'reset', originalPassword)
@@ -12,23 +19,27 @@ test('user can reset password and log in with the new password', async ({ page }
   }
   await page.locator('#logout').click()
   await expect(page.locator('#login')).toBeVisible()
+  await expect(page.getByTestId('login-form')).toBeVisible()
 
-  await page.locator('#forgot').click()
-  await page.locator('#email').fill(email)
-  await page.locator('#send').click()
-  await expect(page.getByRole('heading', { name: 'Complete' })).toBeVisible()
+  await page.getByTestId('login-forgot').click()
+  await expect(page.getByTestId('forgot-form')).toBeVisible()
+  await fillStable(page.getByTestId('forgot-email'), email)
+  await page.getByTestId('forgot-send').click()
+  await expect(page.getByTestId('check-email-complete')).toBeVisible()
 
   const resetUrl = await waitForResetUrl()
   const newPassword = 'password456'
 
   await page.goto(resetUrl)
-  await page.locator('#password').fill(newPassword)
-  await page.locator('#reset').click()
+  await expect(page.getByTestId('reset-form')).toBeVisible()
+  await fillStable(page.getByTestId('reset-password'), newPassword)
+  await page.getByTestId('reset-submit').click()
   await expect(page).toHaveURL(/\/login$/)
 
-  await page.locator('#email').fill(email)
-  await page.locator('#password').fill(newPassword)
-  await page.locator('#submit').click()
+  await expect(page.getByTestId('login-form')).toBeVisible()
+  await fillStable(page.getByTestId('login-email'), email)
+  await fillStable(page.getByTestId('login-password'), newPassword)
+  await page.getByTestId('login-submit').click()
 
   await expect(page.locator('#no_domains')).toBeVisible()
 })

--- a/web/src/views/CheckEmail.vue
+++ b/web/src/views/CheckEmail.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container" style="text-align: center">
-    <h2 style="padding-bottom: 20px">Complete</h2>
+    <h2 style="padding-bottom: 20px" data-testid="check-email-complete">Complete</h2>
     <span>
       Check your mailbox
     </span>

--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container">
-  <form class="form-horizontal" @submit="login">
+  <form class="form-horizontal" data-testid="login-form" @submit="login">
     <h2>Log in</h2>
     <br/>
 
@@ -15,7 +15,7 @@
           <label class="control-label" for="email">Email</label>
         </div>
         <div class="col-9 col-md-9 col-sm-9 col-lg-9">
-          <input id="email" type="text" placeholder="user@mail.com" class="form-control input-md" required="" v-model="email">
+          <input id="email" data-testid="login-email" type="text" placeholder="user@mail.com" class="form-control input-md" required="" v-model="email">
           <span id="help-email" class="help-block">{{ emailError }}</span>
         </div>
       </div>
@@ -25,15 +25,15 @@
           <label class="control-label" for="password">Password</label>
         </div>
         <div class="col-9 col-md-9 col-sm-9 col-lg-9">
-          <input id="password" type="password" placeholder="" class="form-control input-md" required="" v-model="password">
+          <input id="password" data-testid="login-password" type="password" placeholder="" class="form-control input-md" required="" v-model="password">
           <span id="help-password" class="help-block">{{ passwordError }}</span>
         </div>
       </div>
 
       <div class="form-group">
         <div class="button-block col-12 col-md-12 col-sm-12 col-lg-12" style="padding-right:15px; padding-left:15px;">
-          <router-link to="/forgot" id="forgot" class="pull-left" style="padding-top: 10px;">Forgot your password?</router-link>
-          <button id="submit" class="btn btn-primary pull-right" >Log in</button>
+          <router-link to="/forgot" id="forgot" data-testid="login-forgot" class="pull-left" style="padding-top: 10px;">Forgot your password?</router-link>
+          <button id="submit" data-testid="login-submit" class="btn btn-primary pull-right" >Log in</button>
         </div>
       </div>
 

--- a/web/src/views/PasswordForgot.vue
+++ b/web/src/views/PasswordForgot.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
 
-  <form class="form-horizontal" id="form-forgot" @submit="reset">
+  <form class="form-horizontal" id="form-forgot" data-testid="forgot-form" @submit="reset">
     <h2>Forgot your password?</h2>
     <br/>
     <fieldset>
@@ -15,13 +15,13 @@
           <label class="control-label" for="email">Email</label>
         </div>
         <div class="col-12 col-md-12 col-sm-12 col-lg-12">
-          <input id="email" name="email" type="text" placeholder="user@mail.com" class="form-control input-md" required="" v-model="email">
+          <input id="email" name="email" data-testid="forgot-email" type="text" placeholder="user@mail.com" class="form-control input-md" required="" v-model="email">
         </div>
       </div>
 
       <div class="form-group">
         <div class="button-block col-12 col-md-12 col-sm-12 col-lg-12" style="padding-right:15px; padding-left:15px;">
-          <button id="send" class="btn btn-primary pull-right">Submit</button>
+          <button id="send" data-testid="forgot-send" class="btn btn-primary pull-right">Submit</button>
         </div>
       </div>
 

--- a/web/src/views/PasswordReset.vue
+++ b/web/src/views/PasswordReset.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <form class="form-horizontal">
+  <form class="form-horizontal" data-testid="reset-form">
     <h2>Reset password</h2>
     <br/>
     <fieldset>
@@ -16,13 +16,13 @@
           <label class="control-label" for="password">New password</label>
         </div>
         <div class="col-8 col-md-8 col-sm-8 col-lg-8">
-          <input id="password" type="password" placeholder="" class="form-control input-md" required="" v-model="password">
+          <input id="password" data-testid="reset-password" type="password" placeholder="" class="form-control input-md" required="" v-model="password">
         </div>
       </div>
 
       <div class="form-group" v-if="error === ''">
         <div class="button-block col-12 col-md-12 col-sm-12 col-lg-12" style="padding-right:15px; padding-left:15px;">
-          <button id="reset" class="btn btn-primary pull-right" @click="reset">Reset</button>
+          <button id="reset" data-testid="reset-submit" class="btn btn-primary pull-right" @click="reset">Reset</button>
         </div>
       </div>
 


### PR DESCRIPTION
Two unrelated defects, both found while validating the prod relay deploy.

## Relay auth returned a transient code for permanent failures

Probing prod with a bad token returned `454 4.7.0 unknown login or password`. `Session.Auth` returned the raw error from `Relay.Authorize`, and go-smtp maps a plain `error` to `454 4.7.0` — the same trap as the `554`/`451` mapping already fixed in `Data()`.

So a device with a wrong or revoked token, one on a plan without the relay, and one blocked after spam complaints were all told "temporary, try again", which means retrying until the sending queue expires instead of failing fast with a usable message.

Mapping now:

| condition | before | after |
|---|---|---|
| unknown token / login not the token's domain | 454 | **535 5.7.8** |
| plan without relay | 454 | **535 5.7.8** |
| blocked after spam complaints | 454 | **535 5.7.8** |
| monthly limit exceeded | 454 | 454 4.7.0 |
| store/db error | 454 (leaked internals) | 454 4.7.0, generic message |

The monthly limit stays transient — it genuinely clears — and unexpected store errors stay transient but no longer leak the underlying error to the client.

`TestRelayServer_RejectsWrongPassword` asserted only `assert.Error`, never the code, which is why this was invisible. It now asserts `535`, joined by four cases covering foreign login, blocked, plan-without-relay and over-limit. Reverting the mapping fails them with `expected reply starting with 535, got "454 4.7.0 unknown login or password"`.

## Password reset e2e flake

Build 1429 failed `test-ui-mobile` on `password-reset.spec.js`, blocking the prod deploy. Not infrastructure — a real race in the test.

`#email` exists on both `Login.vue` and `PasswordForgot.vue`. The test clicked `#forgot` (a client-side `router-link`) and immediately filled `#email` with no wait for the transition. When the fill won the race it typed into the **login** form; the router then rendered `PasswordForgot` with an empty `#email`, and clicking `#send` submitted an empty `required` field, which the browser blocks natively — no request reached the backend and the app never navigated to `/check-email`.

The failure screenshot shows the empty field with the native "Please fill out this field" bubble, and the api log for the retry contains no `POST /user/reset_password` at all.

Fixed by waiting for each page to render before touching its inputs, and asserting the filled value stuck. The same latent race existed on the `#password` pair (`Login` / `PasswordReset`) after the reset submit, so that transition is guarded too.

Selectors moved to `data-testid` (added to the views; existing ids kept, so other specs are unaffected), which also removes the text-based `getByRole('heading', { name: 'Complete' })`.