### PR TITLE
Chart mail relay messages per domain

### DIFF
--- a/backend/clock/system_clock.go
+++ b/backend/clock/system_clock.go
@@ -1,0 +1,14 @@
+package clock
+
+import "time"
+
+type SystemClock struct {
+}
+
+func New() *SystemClock {
+	return &SystemClock{}
+}
+
+func (c *SystemClock) Now() time.Time {
+	return time.Now()
+}

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -43,9 +43,10 @@ func main() {
 				scanner *mailrelay.Rspamd,
 				mailRelay *mailrelay.Server,
 				reputation *mailrelay.Reputation,
+				usageMetrics *mailrelay.UsageMetrics,
 				config *utils.Config,
 			) error {
-				metricsServer := metrics.NewServer(config.GetApiMetricsAddr(), log.Default(), metricsCollector, relayAccountant, reputation)
+				metricsServer := metrics.NewServer(config.GetApiMetricsAddr(), log.Default(), metricsCollector, relayAccountant, reputation, usageMetrics)
 				services := []service.Startable{
 					migrator,
 					database,

--- a/backend/db/mysql.go
+++ b/backend/db/mysql.go
@@ -759,6 +759,25 @@ func (m *MySql) GetMailRelayUsageForUser(userId int64, yearMonth string) (int64,
 	return messages, nil
 }
 
+func (m *MySql) GetMailRelayUsageAll(yearMonth string) ([]model.MailRelayDomainUsage, error) {
+	rows, err := m.db.Query(
+		"SELECT name, COALESCE(messages, 0), COALESCE(bounces, 0) FROM mail_relay_usage WHERE `year_month` = ?",
+		yearMonth)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var usage []model.MailRelayDomainUsage
+	for rows.Next() {
+		var entry model.MailRelayDomainUsage
+		if err := rows.Scan(&entry.Name, &entry.Messages, &entry.Bounces); err != nil {
+			return nil, err
+		}
+		usage = append(usage, entry)
+	}
+	return usage, rows.Err()
+}
+
 func (m *MySql) BlockMailRelay(name string, reason string) error {
 	stmt, err := m.db.Prepare(
 		"INSERT INTO mail_relay_blocked (name, reason) VALUES (?, ?) " +

--- a/backend/ioc/ioc.go
+++ b/backend/ioc/ioc.go
@@ -371,6 +371,13 @@ func NewContainer(configPath string, secretPath string, mailPath string) (contai
 		return nil, err
 	}
 
+	err = c.Singleton(func(database *db.MySql) *mailrelay.UsageMetrics {
+		return mailrelay.NewUsageMetrics(database, logger)
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	err = c.Singleton(func(awsSession *session.Session, config *utils.Config) *mailrelay.Reputation {
 		source := mailrelay.NewCloudWatch(awsSession, config.GetMailRelaySesRegion(), time.Hour)
 		return mailrelay.NewReputation(source, time.Duration(config.GetMailRelayReputationIntervalSeconds())*time.Second, logger)

--- a/backend/ioc/ioc.go
+++ b/backend/ioc/ioc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/golobby/container/v3"
 	"github.com/syncloud/redirect/change"
+	"github.com/syncloud/redirect/clock"
 	"github.com/syncloud/redirect/db"
 	"github.com/syncloud/redirect/dns"
 	"github.com/syncloud/redirect/log"
@@ -371,8 +372,15 @@ func NewContainer(configPath string, secretPath string, mailPath string) (contai
 		return nil, err
 	}
 
-	err = c.Singleton(func(database *db.MySql) *mailrelay.UsageMetrics {
-		return mailrelay.NewUsageMetrics(database, logger)
+	err = c.Singleton(func() *clock.SystemClock {
+		return clock.New()
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.Singleton(func(database *db.MySql, systemClock *clock.SystemClock) *mailrelay.UsageMetrics {
+		return mailrelay.NewUsageMetrics(database, systemClock, logger)
 	})
 	if err != nil {
 		return nil, err

--- a/backend/mailrelay/usage_metrics.go
+++ b/backend/mailrelay/usage_metrics.go
@@ -12,19 +12,23 @@ type UsageMetricsStore interface {
 	GetMailRelayUsageAll(yearMonth string) ([]model.MailRelayDomainUsage, error)
 }
 
+type Clock interface {
+	Now() time.Time
+}
+
 type UsageMetrics struct {
 	store  UsageMetricsStore
-	now    func() time.Time
+	clock  Clock
 	logger *zap.Logger
 
 	messagesDesc *prometheus.Desc
 	bouncesDesc  *prometheus.Desc
 }
 
-func NewUsageMetrics(store UsageMetricsStore, logger *zap.Logger) *UsageMetrics {
+func NewUsageMetrics(store UsageMetricsStore, clock Clock, logger *zap.Logger) *UsageMetrics {
 	return &UsageMetrics{
 		store:  store,
-		now:    time.Now,
+		clock:  clock,
 		logger: logger,
 		messagesDesc: prometheus.NewDesc(
 			"redirect_mail_relay_messages", "Mail relay messages this month, by domain.", []string{"domain"}, nil),
@@ -39,7 +43,7 @@ func (m *UsageMetrics) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (m *UsageMetrics) Collect(ch chan<- prometheus.Metric) {
-	usage, err := m.store.GetMailRelayUsageAll(m.now().UTC().Format("2006-01"))
+	usage, err := m.store.GetMailRelayUsageAll(m.clock.Now().UTC().Format("2006-01"))
 	if err != nil {
 		m.logger.Warn("cannot read mail relay usage", zap.Error(err))
 		return

--- a/backend/mailrelay/usage_metrics.go
+++ b/backend/mailrelay/usage_metrics.go
@@ -1,0 +1,51 @@
+package mailrelay
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/syncloud/redirect/model"
+	"go.uber.org/zap"
+)
+
+type UsageMetricsStore interface {
+	GetMailRelayUsageAll(yearMonth string) ([]model.MailRelayDomainUsage, error)
+}
+
+type UsageMetrics struct {
+	store  UsageMetricsStore
+	now    func() time.Time
+	logger *zap.Logger
+
+	messagesDesc *prometheus.Desc
+	bouncesDesc  *prometheus.Desc
+}
+
+func NewUsageMetrics(store UsageMetricsStore, logger *zap.Logger) *UsageMetrics {
+	return &UsageMetrics{
+		store:  store,
+		now:    time.Now,
+		logger: logger,
+		messagesDesc: prometheus.NewDesc(
+			"redirect_mail_relay_messages", "Mail relay messages this month, by domain.", []string{"domain"}, nil),
+		bouncesDesc: prometheus.NewDesc(
+			"redirect_mail_relay_bounces", "Mail relay bounces this month, by domain.", []string{"domain"}, nil),
+	}
+}
+
+func (m *UsageMetrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- m.messagesDesc
+	ch <- m.bouncesDesc
+}
+
+func (m *UsageMetrics) Collect(ch chan<- prometheus.Metric) {
+	usage, err := m.store.GetMailRelayUsageAll(m.now().UTC().Format("2006-01"))
+	if err != nil {
+		m.logger.Warn("cannot read mail relay usage", zap.Error(err))
+		return
+	}
+	for _, entry := range usage {
+		ch <- prometheus.MustNewConstMetric(m.messagesDesc, prometheus.GaugeValue, float64(entry.Messages), entry.Name)
+		ch <- prometheus.MustNewConstMetric(m.bouncesDesc, prometheus.GaugeValue, float64(entry.Bounces), entry.Name)
+	}
+}

--- a/backend/mailrelay/usage_metrics_test.go
+++ b/backend/mailrelay/usage_metrics_test.go
@@ -1,0 +1,68 @@
+package mailrelay
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/syncloud/redirect/model"
+	"go.uber.org/zap"
+)
+
+type fakeUsageMetricsStore struct {
+	usage     []model.MailRelayDomainUsage
+	err       error
+	yearMonth string
+}
+
+func (f *fakeUsageMetricsStore) GetMailRelayUsageAll(yearMonth string) ([]model.MailRelayDomainUsage, error) {
+	f.yearMonth = yearMonth
+	return f.usage, f.err
+}
+
+func usageMetricsFor(store UsageMetricsStore) *UsageMetrics {
+	metrics := NewUsageMetrics(store, zap.NewNop())
+	metrics.now = func() time.Time { return time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC) }
+	return metrics
+}
+
+func samples(t *testing.T, metrics *UsageMetrics) map[string]float64 {
+	t.Helper()
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(metrics)
+	families, err := registry.Gather()
+	assert.NoError(t, err)
+	values := map[string]float64{}
+	for _, family := range families {
+		for _, metric := range family.GetMetric() {
+			domain := ""
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "domain" {
+					domain = label.GetValue()
+				}
+			}
+			values[fmt.Sprintf("%s{%s}", family.GetName(), domain)] = metric.GetGauge().GetValue()
+		}
+	}
+	return values
+}
+
+func TestUsageMetrics_PerDomain(t *testing.T) {
+	store := &fakeUsageMetricsStore{usage: []model.MailRelayDomainUsage{
+		{Name: "one.syncloud.it", Messages: 12, Bounces: 1},
+		{Name: "two.syncloud.it", Messages: 3, Bounces: 0},
+	}}
+	values := samples(t, usageMetricsFor(store))
+
+	assert.Equal(t, 12.0, values["redirect_mail_relay_messages{one.syncloud.it}"])
+	assert.Equal(t, 1.0, values["redirect_mail_relay_bounces{one.syncloud.it}"])
+	assert.Equal(t, 3.0, values["redirect_mail_relay_messages{two.syncloud.it}"])
+	assert.Equal(t, "2026-08", store.yearMonth)
+}
+
+func TestUsageMetrics_StoreErrorEmitsNothing(t *testing.T) {
+	store := &fakeUsageMetricsStore{err: fmt.Errorf("database is down")}
+	assert.Empty(t, samples(t, usageMetricsFor(store)))
+}

--- a/backend/mailrelay/usage_metrics_test.go
+++ b/backend/mailrelay/usage_metrics_test.go
@@ -22,10 +22,16 @@ func (f *fakeUsageMetricsStore) GetMailRelayUsageAll(yearMonth string) ([]model.
 	return f.usage, f.err
 }
 
+type fakeClock struct {
+	now time.Time
+}
+
+func (f *fakeClock) Now() time.Time {
+	return f.now
+}
+
 func usageMetricsFor(store UsageMetricsStore) *UsageMetrics {
-	metrics := NewUsageMetrics(store, zap.NewNop())
-	metrics.now = func() time.Time { return time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC) }
-	return metrics
+	return NewUsageMetrics(store, &fakeClock{now: time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)}, zap.NewNop())
 }
 
 func samples(t *testing.T, metrics *UsageMetrics) map[string]float64 {

--- a/backend/model/mail_relay_domain_usage.go
+++ b/backend/model/mail_relay_domain_usage.go
@@ -1,0 +1,7 @@
+package model
+
+type MailRelayDomainUsage struct {
+	Name     string
+	Messages int64
+	Bounces  int64
+}

--- a/monitoring/grafana/redirect-v2.json
+++ b/monitoring/grafana/redirect-v2.json
@@ -449,47 +449,43 @@
       }
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.03
-              },
-              {
-                "color": "red",
-                "value": 0.05
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
+      "id": 16,
+      "title": "Mail relay messages per domain (this month)",
+      "type": "timeseries",
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 56
       },
-      "id": 14,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "redirect_mail_relay_messages{env=\"$env\"}",
+          "legendFormat": "{{domain}}",
+          "refId": "A"
         }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 14,
+      "title": "SES reputation ($env)",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 64
       },
       "targets": [
         {
@@ -498,69 +494,39 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "expr": "redirect_ses_bounce_rate{env=\"$env\"}",
-          "legendFormat": "SES bounce rate ($env)",
+          "legendFormat": "bounce rate",
           "refId": "A"
-        }
-      ],
-      "title": "SES bounce rate ($env)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.0005
-              },
-              {
-                "color": "red",
-                "value": 0.001
-              }
-            ]
-          }
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 56
-      },
-      "id": 15,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        }
-      },
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
           "expr": "redirect_ses_complaint_rate{env=\"$env\"}",
-          "legendFormat": "SES complaint rate ($env)",
-          "refId": "A"
+          "legendFormat": "complaint rate",
+          "refId": "B"
         }
       ],
-      "title": "SES complaint rate ($env)",
-      "type": "timeseries"
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "complaint rate"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
The traffic relay publishes `redirect_relay_traffic_bytes{proxy}` and has a "Relay traffic per user" panel. The mail relay published only the two global SES rates, so there was no way to see which domains are sending.

## Per domain metrics

`mail_relay_usage` already holds one row per domain per month, written on every send, so nothing new needs recording:

- `redirect_mail_relay_messages{domain}`
- `redirect_mail_relay_bounces{domain}`

A collector reads the table on scrape rather than keeping an in-memory tally. That costs one small query per scrape — the table has a row per sending domain per month — and in exchange the numbers survive a restart and stay correct if more than one instance ever serves the relay. The traffic relay's `Accountant` counts in memory because it is already counting bytes on live connections; it loses its totals on restart, so copying that here would have been the worse half of the trade.

A store error logs and emits nothing, so a database blip leaves a gap in the graph rather than a drop to zero that looks like traffic stopping.

## One SES panel instead of two

The bounce and complaint panels are merged into "SES reputation". Complaint rate is on the right axis: it runs around 0.0005 against a bounce rate around 0.02, so on a shared axis it would be a flat line on zero and the merge would have made it less readable, not more.

The per-panel colour thresholds are dropped, since a single threshold set cannot serve two series with limits 40x apart — the SES limits they encoded (0.05 bounce, 0.001 complaint) are still the numbers that matter, they are just no longer painted on the panel.