### PR TITLE
Count inbound mail bytes where the domain is known

### DIFF
--- a/backend/ioc/ioc.go
+++ b/backend/ioc/ioc.go
@@ -474,7 +474,8 @@ func NewContainer(configPath string, secretPath string, mailPath string) (contai
 		return nil, err
 	}
 
-	err = c.Singleton(func(router *inbound.Router, dialer inbound.DeviceDialer, config *utils.Config) *inbound.Server {
+	err = c.Singleton(func(router *inbound.Router, dialer inbound.DeviceDialer,
+		accountant *relay.Accountant, config *utils.Config) *inbound.Server {
 		return inbound.NewServer(
 			config.GetMailInboundAddress(),
 			config.GetMailInboundHostname(),
@@ -482,6 +483,7 @@ func NewContainer(configPath string, secretPath string, mailPath string) (contai
 			dialer,
 			mail.NewConnections(config.GetMailInboundMaxConnectionsPerPeer()),
 			mail.NewInFlight(config.GetMailInboundMaxConcurrent()),
+			accountant,
 			config.GetMailInboundMaxMessageBytes(),
 			logger)
 	})

--- a/backend/mail/inbound/server.go
+++ b/backend/mail/inbound/server.go
@@ -19,8 +19,8 @@ type Server struct {
 }
 
 func NewServer(address string, hostname string, router *Router, dialer DeviceDialer,
-	connections *mail.Connections, inFlight *mail.InFlight, maxMessageBytes int64,
-	logger *zap.Logger) *Server {
+	connections *mail.Connections, inFlight *mail.InFlight, traffic Traffic,
+	maxMessageBytes int64, logger *zap.Logger) *Server {
 	s := &Server{logger: logger}
 	server := smtp.NewServer(smtp.BackendFunc(func(c *smtp.Conn) (smtp.Session, error) {
 		peer := peerOf(c)
@@ -30,6 +30,7 @@ func NewServer(address string, hostname string, router *Router, dialer DeviceDia
 		}
 		return &Session{
 			router: router, dialer: dialer, connections: connections, inFlight: inFlight,
+			traffic:  traffic,
 			hostname: hostname, peer: peer, logger: logger,
 		}, nil
 	}))

--- a/backend/mail/inbound/server_test.go
+++ b/backend/mail/inbound/server_test.go
@@ -103,6 +103,31 @@ func tunnelTo(domain string, device *fakeDevice) *fakeDialer {
 	return &fakeDialer{devices: map[string]string{domain: device.address}}
 }
 
+type fakeTraffic struct {
+	mutex    sync.Mutex
+	over     bool
+	recorded map[string]int64
+}
+
+func (f *fakeTraffic) OverLimit(_ string) bool {
+	return f.over
+}
+
+func (f *fakeTraffic) Record(domain string, bytes int64) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	if f.recorded == nil {
+		f.recorded = map[string]int64{}
+	}
+	f.recorded[domain] += bytes
+}
+
+func (f *fakeTraffic) bytes(domain string) int64 {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	return f.recorded[domain]
+}
+
 type fakeStore struct {
 	domains map[string]*model.Domain
 }
@@ -112,32 +137,34 @@ func (f *fakeStore) GetDomainByName(name string) (*model.Domain, error) {
 }
 
 func relayed(dialer DeviceDialer, domains map[string]*model.Domain) (string, func(), error) {
-	return relayedWith(dialer, domains, mail.NewConnections(0))
+	address, stop, _, err := relayedWith(dialer, domains, mail.NewConnections(0), &fakeTraffic{})
+	return address, stop, err
 }
 
 func relayedWith(dialer DeviceDialer, domains map[string]*model.Domain,
-	connections *mail.Connections) (string, func(), error) {
+	connections *mail.Connections, traffic Traffic) (string, func(), *fakeTraffic, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 	address := listener.Addr().String()
 	if err := listener.Close(); err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 
 	router := NewRouter(&fakeStore{domains: domains})
 	server := NewServer(address, "mx.syncloud.it", router, dialer, connections,
-		mail.NewInFlight(0), 1024*1024, zap.NewNop())
+		mail.NewInFlight(0), traffic, 1024*1024, zap.NewNop())
 	if err := server.Start(); err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 	stop := func() { _ = server.Close() }
 	if err := waitListening(address); err != nil {
 		stop()
-		return "", nil, err
+		return "", nil, nil, err
 	}
-	return address, stop, nil
+	counter, _ := traffic.(*fakeTraffic)
+	return address, stop, counter, nil
 }
 
 func waitListening(address string) error {
@@ -342,9 +369,9 @@ func TestInbound_ProxyProtocolKeepsSendersApart(t *testing.T) {
 	device, stopDevice, err := startDevice(&fakeDevice{})
 	assert.NoError(t, err)
 	defer stopDevice()
-	address, stop, err := relayedWith(tunnelTo("alice.syncloud.it", device), map[string]*model.Domain{
-		"alice.syncloud.it": relayDomain("alice.syncloud.it")},
-		mail.NewConnections(1))
+	address, stop, _, err := relayedWith(tunnelTo("alice.syncloud.it", device),
+		map[string]*model.Domain{"alice.syncloud.it": relayDomain("alice.syncloud.it")},
+		mail.NewConnections(1), &fakeTraffic{})
 	assert.NoError(t, err)
 	defer stop()
 
@@ -363,9 +390,9 @@ func TestInbound_ProxyProtocolLimitsOneSender(t *testing.T) {
 	device, stopDevice, err := startDevice(&fakeDevice{})
 	assert.NoError(t, err)
 	defer stopDevice()
-	address, stop, err := relayedWith(tunnelTo("alice.syncloud.it", device), map[string]*model.Domain{
-		"alice.syncloud.it": relayDomain("alice.syncloud.it")},
-		mail.NewConnections(1))
+	address, stop, _, err := relayedWith(tunnelTo("alice.syncloud.it", device),
+		map[string]*model.Domain{"alice.syncloud.it": relayDomain("alice.syncloud.it")},
+		mail.NewConnections(1), &fakeTraffic{})
 	assert.NoError(t, err)
 	defer stop()
 
@@ -397,7 +424,36 @@ func TestInbound_PortConflictStopsTheApi(t *testing.T) {
 
 	server := NewServer(held.Addr().String(), "mx.syncloud.it",
 		NewRouter(&fakeStore{domains: map[string]*model.Domain{}}), &fakeDialer{},
-		mail.NewConnections(0), mail.NewInFlight(0), 1024*1024, zap.NewNop())
+		mail.NewConnections(0), mail.NewInFlight(0), &fakeTraffic{}, 1024*1024, zap.NewNop())
 
 	assert.Error(t, server.Start())
+}
+
+func TestInbound_CountsTheBytesItRelays(t *testing.T) {
+	device, stopDevice, err := startDevice(&fakeDevice{})
+	assert.NoError(t, err)
+	defer stopDevice()
+	address, stop, traffic, err := relayedWith(tunnelTo("alice.syncloud.it", device),
+		map[string]*model.Domain{"alice.syncloud.it": relayDomain("alice.syncloud.it")},
+		mail.NewConnections(0), &fakeTraffic{})
+	assert.NoError(t, err)
+	defer stop()
+
+	assert.NoError(t, deliver(address, "user@alice.syncloud.it"))
+
+	assert.Greater(t, traffic.bytes("alice.syncloud.it"), int64(0))
+}
+
+func TestInbound_OverTheLimitIsDeferred(t *testing.T) {
+	device, stopDevice, err := startDevice(&fakeDevice{})
+	assert.NoError(t, err)
+	defer stopDevice()
+	address, stop, traffic, err := relayedWith(tunnelTo("alice.syncloud.it", device),
+		map[string]*model.Domain{"alice.syncloud.it": relayDomain("alice.syncloud.it")},
+		mail.NewConnections(0), &fakeTraffic{over: true})
+	assert.NoError(t, err)
+	defer stop()
+
+	assertCode(t, deliver(address, "user@alice.syncloud.it"), "451")
+	assert.Equal(t, int64(0), traffic.bytes("alice.syncloud.it"))
 }

--- a/backend/mail/inbound/session.go
+++ b/backend/mail/inbound/session.go
@@ -11,6 +11,7 @@ import (
 )
 
 var (
+	ErrOverLimit     = errors.New("monthly relay limit exceeded, try again later")
 	ErrUnreachable   = errors.New("device is not reachable, try again later")
 	ErrNoRecipients  = errors.New("no valid recipients")
 	ErrMixedDomains  = errors.New("too many recipients, send to one domain per message")
@@ -20,6 +21,7 @@ var (
 type Session struct {
 	router      *Router
 	dialer      DeviceDialer
+	traffic     Traffic
 	connections *mail.Connections
 	inFlight    *mail.InFlight
 	hostname    string
@@ -44,6 +46,10 @@ func (s *Session) Rcpt(to string, _ *smtp.RcptOptions) error {
 		return routeError(err)
 	}
 	if s.domain == "" {
+		if s.traffic.OverLimit(domain) {
+			s.logger.Info("inbound over the monthly limit", zap.String("domain", domain))
+			return tryAgain(ErrOverLimit, smtp.EnhancedCode{4, 5, 3})
+		}
 		if err := s.connect(domain); err != nil {
 			return err
 		}
@@ -79,7 +85,9 @@ func (s *Session) Data(r io.Reader) error {
 	if err != nil {
 		return relayError(err)
 	}
-	if _, err := io.Copy(writer, r); err != nil {
+	written, err := io.Copy(writer, r)
+	s.traffic.Record(s.domain, written)
+	if err != nil {
 		_ = writer.Close()
 		return relayError(err)
 	}

--- a/backend/mail/inbound/traffic.go
+++ b/backend/mail/inbound/traffic.go
@@ -1,0 +1,6 @@
+package inbound
+
+type Traffic interface {
+	OverLimit(domain string) bool
+	Record(domain string, bytes int64)
+}

--- a/backend/relay/accountant.go
+++ b/backend/relay/accountant.go
@@ -170,6 +170,26 @@ func (a *Accountant) recomputeOver() []warning {
 	return warnings
 }
 
+func (a *Accountant) Record(name string, bytes int64) {
+	if bytes <= 0 {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	current := month()
+	if current != a.month {
+		a.month = current
+		a.monthly = map[string]int64{}
+		a.over = map[string]bool{}
+		a.warned = map[int64]bool{}
+	}
+	a.monthly[name] += bytes
+	if err := a.db.AddRelayTraffic(name, current, bytes); err != nil {
+		a.logger.Warn("relay traffic persist failed",
+			zap.String("proxy", name), zap.Error(err))
+	}
+}
+
 func (a *Accountant) OverLimit(name string) bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/backend/relay/accountant_test.go
+++ b/backend/relay/accountant_test.go
@@ -168,22 +168,7 @@ something_else{name="alice.syncloud.it"} 999`
 	assert.Equal(t, int64(50), totals["bob.syncloud.it"])
 }
 
-func TestAccountant_SmtpAndWebProxiesShareOneUserLimit(t *testing.T) {
-	tiers := NewTiers(newDomainStore(), 1, 10, 100, zap.NewNop())
-	source := &fakeSource{values: []map[string]int64{
-		{"alice.syncloud.it": 0, "alice.syncloud.it-smtp": 0},
-		{"alice.syncloud.it": 60, "alice.syncloud.it-smtp": 60},
-	}}
-	a := newAccountant(tiers, source, &fakeRelayDb{})
-
-	a.poll()
-	a.poll()
-
-	assert.True(t, a.OverLimit("alice.syncloud.it-smtp"))
-	assert.True(t, a.OverLimit("alice.syncloud.it"))
-}
-
-func TestAccountant_SmtpOnlyTrafficCountsTowardsTheLimit(t *testing.T) {
+func TestAccountant_TunnelProxyTrafficIsNotAttributed(t *testing.T) {
 	tiers := NewTiers(newDomainStore(), 1, 10, 100, zap.NewNop())
 	source := &fakeSource{values: []map[string]int64{
 		{"alice.syncloud.it-smtp": 0},
@@ -194,19 +179,41 @@ func TestAccountant_SmtpOnlyTrafficCountsTowardsTheLimit(t *testing.T) {
 	a.poll()
 	a.poll()
 
-	assert.True(t, a.OverLimit("alice.syncloud.it-smtp"))
+	assert.False(t, a.OverLimit("alice.syncloud.it-smtp"))
+	assert.False(t, a.OverLimit("alice.syncloud.it"))
 }
 
-func TestAccountant_SmtpTrafficUnderTheLimitIsAllowed(t *testing.T) {
+func TestAccountant_RecordedInboundBytesCountTowardsTheLimit(t *testing.T) {
+	tiers := NewTiers(newDomainStore(), 1, 10, 100, zap.NewNop())
+	a := newAccountant(tiers, &fakeSource{values: []map[string]int64{{}}}, &fakeRelayDb{})
+
+	a.Record("alice.syncloud.it", 150)
+	a.poll()
+
+	assert.True(t, a.OverLimit("alice.syncloud.it"))
+}
+
+func TestAccountant_RecordedInboundBytesUnderTheLimitAreAllowed(t *testing.T) {
+	tiers := NewTiers(newDomainStore(), 1, 10, 100, zap.NewNop())
+	a := newAccountant(tiers, &fakeSource{values: []map[string]int64{{}}}, &fakeRelayDb{})
+
+	a.Record("alice.syncloud.it", 40)
+	a.poll()
+
+	assert.False(t, a.OverLimit("alice.syncloud.it"))
+}
+
+func TestAccountant_RecordedBytesAddToWebTraffic(t *testing.T) {
 	tiers := NewTiers(newDomainStore(), 1, 10, 100, zap.NewNop())
 	source := &fakeSource{values: []map[string]int64{
-		{"alice.syncloud.it-smtp": 0},
-		{"alice.syncloud.it-smtp": 40},
+		{"alice.syncloud.it": 0},
+		{"alice.syncloud.it": 60},
 	}}
 	a := newAccountant(tiers, source, &fakeRelayDb{})
 
 	a.poll()
+	a.Record("alice.syncloud.it", 60)
 	a.poll()
 
-	assert.False(t, a.OverLimit("alice.syncloud.it-smtp"))
+	assert.True(t, a.OverLimit("alice.syncloud.it"))
 }

--- a/backend/relay/tiers.go
+++ b/backend/relay/tiers.go
@@ -1,13 +1,9 @@
 package relay
 
 import (
-	"strings"
-
 	"github.com/syncloud/redirect/model"
 	"go.uber.org/zap"
 )
-
-const SmtpProxySuffix = "-smtp"
 
 type DomainStore interface {
 	GetDomainByName(name string) (*model.Domain, error)
@@ -27,7 +23,7 @@ func NewTiers(store DomainStore, free int64, pro int64, max int64, logger *zap.L
 }
 
 func (t *Tiers) OwnerLimit(name string) (int64, int64, bool) {
-	domain, err := t.store.GetDomainByName(strings.TrimSuffix(name, SmtpProxySuffix))
+	domain, err := t.store.GetDomainByName(name)
 	if err != nil || domain == nil {
 		return 0, 0, false
 	}

--- a/backend/relay/tiers_test.go
+++ b/backend/relay/tiers_test.go
@@ -75,23 +75,21 @@ func TestTiers_OwnerLimit_WebProxy(t *testing.T) {
 	assert.Equal(t, int64(100), limit)
 }
 
-func TestTiers_OwnerLimit_SmtpProxyBelongsToSameUser(t *testing.T) {
+func TestTiers_OwnerLimit_TunnelProxyIsNotADomain(t *testing.T) {
 	store := newDomainStore()
 	tiers := NewTiers(store, 1, 10, 100, zap.NewNop())
 
-	userId, limit, ok := tiers.OwnerLimit("alice.syncloud.it" + SmtpProxySuffix)
+	_, _, ok := tiers.OwnerLimit("alice.syncloud.it-smtp")
 
-	assert.True(t, ok)
-	assert.Equal(t, int64(7), userId)
-	assert.Equal(t, int64(100), limit)
-	assert.Equal(t, []string{"alice.syncloud.it"}, store.asked)
+	assert.False(t, ok)
+	assert.Equal(t, []string{"alice.syncloud.it-smtp"}, store.asked)
 }
 
 func TestTiers_OwnerLimit_UnknownProxy(t *testing.T) {
 	store := newDomainStore()
 	tiers := NewTiers(store, 1, 10, 100, zap.NewNop())
 
-	_, _, ok := tiers.OwnerLimit("stranger.syncloud.it" + SmtpProxySuffix)
+	_, _, ok := tiers.OwnerLimit("stranger.syncloud.it")
 
 	assert.False(t, ok)
 }

--- a/backend/relay/usage.go
+++ b/backend/relay/usage.go
@@ -20,15 +20,7 @@ func (u *Usage) UsedBytes(userId int64) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return u.store.GetRelayTraffic(ProxyNames(domains), month())
-}
-
-func ProxyNames(domains []string) []string {
-	names := make([]string, 0, len(domains)*2)
-	for _, domain := range domains {
-		names = append(names, domain, domain+SmtpProxySuffix)
-	}
-	return names
+	return u.store.GetRelayTraffic(domains, month())
 }
 
 func (u *Usage) Enabled(userId int64) (bool, error) {

--- a/backend/relay/usage_test.go
+++ b/backend/relay/usage_test.go
@@ -29,12 +29,11 @@ func (f *fakeUsageStore) IsRelayEnabledForUser(_ int64) (bool, error) {
 	return true, nil
 }
 
-func TestUsage_CountsBothProxiesOfEveryDomain(t *testing.T) {
+func TestUsage_CountsEveryDomainOfTheUser(t *testing.T) {
 	store := &fakeUsageStore{
 		domains: []string{"alice.syncloud.it", "spare.syncloud.it"},
 		traffic: map[string]int64{
 			"alice.syncloud.it":         100,
-			"alice.syncloud.it-smtp":    20,
 			"spare.syncloud.it":         3,
 			"somebody-else.syncloud.it": 9000,
 		},
@@ -43,16 +42,16 @@ func TestUsage_CountsBothProxiesOfEveryDomain(t *testing.T) {
 	used, err := NewUsage(store, nil).UsedBytes(1)
 
 	assert.NoError(t, err)
-	assert.Equal(t, int64(123), used)
+	assert.Equal(t, int64(103), used)
 }
 
-func TestUsage_AsksForTheMailProxyOfEachDomain(t *testing.T) {
+func TestUsage_AsksForTheDomainsOfTheUser(t *testing.T) {
 	store := &fakeUsageStore{domains: []string{"alice.syncloud.it"}}
 
 	_, err := NewUsage(store, nil).UsedBytes(1)
 
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"alice.syncloud.it", "alice.syncloud.it-smtp"}, store.asked)
+	assert.Equal(t, []string{"alice.syncloud.it"}, store.asked)
 }
 
 func TestUsage_NoDomainsMeansNoTraffic(t *testing.T) {

--- a/test/test.py
+++ b/test/test.py
@@ -1179,7 +1179,7 @@ def mail_send(host, sender, recipient, subject, attempts=15):
 def mail_send_big(host, sender, recipient):
     server = smtplib.SMTP(host, MAIL_INBOUND_PORT, timeout=30)
     try:
-        message = 'Subject: bulk\r\n\r\n{0}\r\n'.format('x' * 65536)
+        message = 'Subject: bulk\r\n\r\n{0}'.format(('x' * 900 + '\r\n') * 72)
         server.sendmail(sender, [recipient], message)
     finally:
         try:


### PR DESCRIPTION
Traffic comes back from frps keyed by the proxy name the device chose, so attributing it meant `TrimSuffix(name, "-smtp")` and hoping the remainder was a domain.

That guess is wrong two ways:

- a domain whose name really ends in `-smtp` trims to something that does not exist, `OwnerLimit` returns `!ok`, and `recomputeOver` skips it — the traffic is never metered
- a name crafted to be another domain's name plus `-smtp` trims onto that domain, so one user's bytes count against another's limit

The inbound server already knows the domain — the router binds it on the first recipient, before any data moves — so it counts what it relays and asks whether that domain is over its limit, returning 451 rather than letting the tunnel connection fail underneath the sender.

With that, the proxy name is matched exactly and the mail proxy is just a name redirect does not recognise:

- `OwnerLimit` is `GetDomainByName(name)`
- `ProxyNames` and `SmtpProxySuffix` are gone
- `UsedBytes` passes domain names straight through

`Accountant.Record` exists because `monthly` is in-memory, seeded once at `Start` and otherwise only advanced by frps deltas — writing to the DB directly would never reach `recomputeOver`.

Platform is unchanged; it still names its proxy `<domain>-smtp` for its own readiness check.

Note the metric shifts slightly for inbound: frps counted raw tunnel bytes both ways, this counts the message stream.