### PR TITLE
Accept inbound mail from senders that omit SNI

### DIFF
--- a/caddy-smtp/handler.go
+++ b/caddy-smtp/handler.go
@@ -43,15 +43,28 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 		return fmt.Errorf("smtp_starttls: upstream is required")
 	}
 	if len(h.ConnectionPolicies) == 0 {
-		h.ConnectionPolicies = append(h.ConnectionPolicies,
-			&caddytls.ConnectionPolicy{DefaultSNI: h.DefaultSni})
+		h.ConnectionPolicies = append(h.ConnectionPolicies, new(caddytls.ConnectionPolicy))
 	}
 	if err := h.ConnectionPolicies.Provision(ctx); err != nil {
 		return fmt.Errorf("smtp_starttls: setting up connection policies: %v", err)
 	}
 	h.conversation = NewConversation(h.Hostname, NewTcpUpstream(h.Upstream),
-		func() *tls.Config { return h.ConnectionPolicies.TLSConfig(h.ctx) }, h.logger)
+		h.tlsConfig, h.logger)
 	return nil
+}
+
+// a name is only expanded to a wildcard when the client sent one, so an
+// unnamed connection is given the default before the certificate is chosen
+func (h *Handler) tlsConfig() *tls.Config {
+	config := h.ConnectionPolicies.TLSConfig(h.ctx)
+	chooseConfig := config.GetConfigForClient
+	config.GetConfigForClient = func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+		if hello.ServerName == "" {
+			hello.ServerName = h.DefaultSni
+		}
+		return chooseConfig(hello)
+	}
+	return config
 }
 
 func (h *Handler) Handle(cx *layer4.Connection, _ layer4.Handler) error {

--- a/caddy-smtp/handler.go
+++ b/caddy-smtp/handler.go
@@ -53,16 +53,27 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 	return nil
 }
 
-// a name is only expanded to a wildcard when the client sent one, so an
-// unnamed connection is given the default before the certificate is chosen
+// a name is only widened to a wildcard when the client sent one, so an unnamed
+// connection is given the default. the hello is rebuilt between choosing the
+// config and choosing the certificate, so the name has to be filled in on the
+// second one to survive
 func (h *Handler) tlsConfig() *tls.Config {
 	config := h.ConnectionPolicies.TLSConfig(h.ctx)
 	chooseConfig := config.GetConfigForClient
 	config.GetConfigForClient = func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
-		if hello.ServerName == "" {
-			hello.ServerName = h.DefaultSni
+		chosen, err := chooseConfig(hello)
+		if err != nil || hello.ServerName != "" || h.DefaultSni == "" {
+			return chosen, err
 		}
-		return chooseConfig(hello)
+		named := chosen.Clone()
+		chooseCertificate := chosen.GetCertificate
+		named.GetCertificate = func(fresh *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			if fresh.ServerName == "" {
+				fresh.ServerName = h.DefaultSni
+			}
+			return chooseCertificate(fresh)
+		}
+		return named, nil
 	}
 	return config
 }

--- a/config/common/caddy/Caddyfile
+++ b/config/common/caddy/Caddyfile
@@ -73,11 +73,6 @@ mail-relay.{$REDIRECT_DOMAIN} {
 	respond 404
 }
 
-mail.mx.{$REDIRECT_DOMAIN} {
-	import syncloud_tls
-	respond 404
-}
-
 {$SHOP_DOMAIN} {
 	import syncloud_tls
 	root * /var/www/shop/opencart

--- a/config/common/caddy/Caddyfile
+++ b/config/common/caddy/Caddyfile
@@ -73,6 +73,11 @@ mail-relay.{$REDIRECT_DOMAIN} {
 	respond 404
 }
 
+mail.mx.{$REDIRECT_DOMAIN} {
+	import syncloud_tls
+	respond 404
+}
+
 {$SHOP_DOMAIN} {
 	import syncloud_tls
 	root * /var/www/shop/opencart

--- a/test/test.py
+++ b/test/test.py
@@ -1,6 +1,7 @@
 import json
 import os
 import smtplib
+import socket
 import ssl
 import subprocess
 import tarfile
@@ -1257,6 +1258,38 @@ def test_mail_inbound_delivers_over_starttls(domain, device_host, artifact_dir, 
     assert 'inbound-starttls' in delivered[1]['body'], delivered
     names = certificate_text(certificate)
     assert '*.mx.{0}'.format(domain) in names, names
+
+
+def mail_starttls_without_sni(host):
+    connection = socket.create_connection((host, MAIL_INBOUND_PORT), timeout=30)
+    stream = connection.makefile('rwb')
+    stream.readline()
+    stream.write(b'EHLO verify.test\r\n')
+    stream.flush()
+    while True:
+        line = stream.readline()
+        if len(line) < 4 or line[3:4] != b'-':
+            break
+    stream.write(b'STARTTLS\r\n')
+    stream.flush()
+    ready = stream.readline()
+    assert ready.startswith(b'220'), ready
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    secure = context.wrap_socket(connection)
+    certificate = secure.getpeercert(binary_form=True)
+    secure.close()
+    return certificate
+
+
+def test_mail_inbound_starttls_without_sni(domain, device_host, artifact_dir, mail_device):
+    domain_name, _ = mail_tunnel(domain, device_host, artifact_dir, mail_device,
+                                 'mailnosni', 'mail_no_sni@syncloud.test')
+
+    certificate = mail_starttls_without_sni(device_host)
+
+    assert certificate, 'the server sent no certificate without sni'
 
 
 def test_mail_inbound_device_rejects_recipient(domain, device_host, artifact_dir, mail_device):

--- a/test/test.py
+++ b/test/test.py
@@ -27,7 +27,7 @@ DIR = dirname(__file__)
 @pytest.fixture(scope="session", autouse=True)
 def server_logs(request, device_host, artifact_dir):
     def teardown():
-        for container in ['redirect-api', 'redirect-www']:
+        for container in ['redirect-api', 'redirect-www', 'caddy']:
             run_ssh(device_host, 'docker logs {0} > /tmp/{0}.log 2>&1'.format(container), throw=False)
             run_scp('root@{0}:/tmp/{1}.log {2}'.format(device_host, container, artifact_dir), throw=False)
     request.addfinalizer(teardown)


### PR DESCRIPTION
A message from Fastmail to a relayed device never arrived. Caddy was refusing the handshake on port 25:

```
"local":"...:25","remote":"202.12.124.158:53727",
"error":"no certificate available for 'mail.mx.syncloud.it'"
```

certmagic only widens a name to a wildcard when the client sent SNI (handshake.go:135-153). With no SNI it looks `DefaultServerName` up exactly and stops, so `*.mx.<domain>` could never answer. Adding a site for the default name does not help either, since caddy will not issue a certificate for a name a wildcard already covers.

So the handler supplies the name itself. It has to happen in the certificate callback rather than in GetConfigForClient: crypto/tls rebuilds the ClientHelloInfo between the two, so a name set on the first is dropped before the lookup. A standalone handshake confirmed that - the certificate callback saw an empty name until the injection moved.

Four sending addresses had been failing this way since the feature deployed. Nothing was lost, as a failed STARTTLS is a temporary error and senders keep retrying for days.

The existing starttls test passed throughout because smtplib always sends SNI. The new test speaks SMTP itself and wraps the socket with no server name; it failed on both earlier attempts at this fix and passes now. Caddy's log joins the collected artifacts, having been the thing I most needed and did not have while diagnosing this.