### PR TITLE
Tell the device who is actually connecting

### DIFF
--- a/backend/ioc/ioc.go
+++ b/backend/ioc/ioc.go
@@ -484,6 +484,7 @@ func NewContainer(configPath string, secretPath string, mailPath string) (contai
 			mail.NewConnections(config.GetMailInboundMaxConnectionsPerPeer()),
 			mail.NewInFlight(config.GetMailInboundMaxConcurrent()),
 			accountant,
+			inbound.NewPtrResolver(inbound.ResolveTimeout),
 			config.GetMailInboundMaxMessageBytes(),
 			logger)
 	})

--- a/backend/mail/inbound/resolver.go
+++ b/backend/mail/inbound/resolver.go
@@ -1,0 +1,34 @@
+package inbound
+
+import (
+	"context"
+	"net"
+	"strings"
+	"time"
+)
+
+type Resolver interface {
+	Name(address string) string
+}
+
+type PtrResolver struct {
+	resolver *net.Resolver
+	timeout  time.Duration
+}
+
+func NewPtrResolver(timeout time.Duration) *PtrResolver {
+	return &PtrResolver{resolver: net.DefaultResolver, timeout: timeout}
+}
+
+func (r *PtrResolver) Name(address string) string {
+	if address == "" {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+	defer cancel()
+	names, err := r.resolver.LookupAddr(ctx, address)
+	if err != nil || len(names) == 0 {
+		return ""
+	}
+	return strings.TrimSuffix(names[0], ".")
+}

--- a/backend/mail/inbound/server.go
+++ b/backend/mail/inbound/server.go
@@ -11,7 +11,10 @@ import (
 	"go.uber.org/zap"
 )
 
-const DialTimeout = 30 * time.Second
+const (
+	DialTimeout    = 30 * time.Second
+	ResolveTimeout = 2 * time.Second
+)
 
 type Server struct {
 	server *smtp.Server
@@ -19,7 +22,7 @@ type Server struct {
 }
 
 func NewServer(address string, hostname string, router *Router, dialer DeviceDialer,
-	connections *mail.Connections, inFlight *mail.InFlight, traffic Traffic,
+	connections *mail.Connections, inFlight *mail.InFlight, traffic Traffic, resolver Resolver,
 	maxMessageBytes int64, logger *zap.Logger) *Server {
 	s := &Server{logger: logger}
 	server := smtp.NewServer(smtp.BackendFunc(func(c *smtp.Conn) (smtp.Session, error) {
@@ -31,7 +34,8 @@ func NewServer(address string, hostname string, router *Router, dialer DeviceDia
 		return &Session{
 			router: router, dialer: dialer, connections: connections, inFlight: inFlight,
 			traffic:  traffic,
-			hostname: hostname, peer: peer, logger: logger,
+			hostname: hostname, peer: peer, helo: c.Hostname(), resolver: resolver,
+			logger: logger,
 		}, nil
 	}))
 	server.Addr = address

--- a/backend/mail/inbound/server_test.go
+++ b/backend/mail/inbound/server_test.go
@@ -154,7 +154,7 @@ func relayedWith(dialer DeviceDialer, domains map[string]*model.Domain,
 
 	router := NewRouter(&fakeStore{domains: domains})
 	server := NewServer(address, "mx.syncloud.it", router, dialer, connections,
-		mail.NewInFlight(0), traffic, 1024*1024, zap.NewNop())
+		mail.NewInFlight(0), traffic, testResolver(), 1024*1024, zap.NewNop())
 	if err := server.Start(); err != nil {
 		return "", nil, nil, err
 	}
@@ -424,7 +424,7 @@ func TestInbound_PortConflictStopsTheApi(t *testing.T) {
 
 	server := NewServer(held.Addr().String(), "mx.syncloud.it",
 		NewRouter(&fakeStore{domains: map[string]*model.Domain{}}), &fakeDialer{},
-		mail.NewConnections(0), mail.NewInFlight(0), &fakeTraffic{}, 1024*1024, zap.NewNop())
+		mail.NewConnections(0), mail.NewInFlight(0), &fakeTraffic{}, testResolver(), 1024*1024, zap.NewNop())
 
 	assert.Error(t, server.Start())
 }

--- a/backend/mail/inbound/session.go
+++ b/backend/mail/inbound/session.go
@@ -26,6 +26,8 @@ type Session struct {
 	inFlight    *mail.InFlight
 	hostname    string
 	peer        string
+	helo        string
+	resolver    Resolver
 	logger      *zap.Logger
 
 	from   string
@@ -107,7 +109,18 @@ func (s *Session) connect(domain string) error {
 			zap.String("domain", domain), zap.Error(err))
 		return tryAgain(ErrUnreachable, smtp.EnhancedCode{4, 4, 1})
 	}
-	client := smtp.NewClient(connection)
+	announced, err := Announce(connection, s.hostname, Client{
+		Address: s.peer,
+		Name:    s.resolver.Name(s.peer),
+		Helo:    s.helo,
+	})
+	if err != nil {
+		_ = connection.Close()
+		s.logger.Info("cannot announce the client to the device",
+			zap.String("domain", domain), zap.Error(err))
+		return relayError(err)
+	}
+	client := smtp.NewClient(announced)
 	if err := client.Hello(s.hostname); err != nil {
 		_ = client.Close()
 		return relayError(err)

--- a/backend/mail/inbound/xclient.go
+++ b/backend/mail/inbound/xclient.go
@@ -1,0 +1,75 @@
+package inbound
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/textproto"
+	"strings"
+)
+
+const Unavailable = "[UNAVAILABLE]"
+
+type Client struct {
+	Address string
+	Name    string
+	Helo    string
+}
+
+type greeted struct {
+	net.Conn
+	reader io.Reader
+}
+
+func (g *greeted) Read(p []byte) (int, error) {
+	return g.reader.Read(p)
+}
+
+func Announce(connection net.Conn, hostname string, client Client) (net.Conn, error) {
+	text := textproto.NewConn(connection)
+	if _, _, err := text.ReadResponse(220); err != nil {
+		return nil, err
+	}
+	if err := text.PrintfLine("EHLO %s", hostname); err != nil {
+		return nil, err
+	}
+	_, capabilities, err := text.ReadResponse(250)
+	if err != nil {
+		return nil, err
+	}
+	if supports(capabilities, "XCLIENT") {
+		if err := text.PrintfLine("XCLIENT %s", attributes(client)); err != nil {
+			return nil, err
+		}
+		if _, _, err := text.ReadResponse(220); err != nil {
+			return nil, err
+		}
+	}
+	greeting := strings.NewReader(fmt.Sprintf("220 %s ESMTP\r\n", hostname))
+	return &greeted{Conn: connection, reader: io.MultiReader(greeting, text.R)}, nil
+}
+
+func supports(capabilities string, extension string) bool {
+	for _, line := range strings.Split(capabilities, "\n") {
+		name, _, _ := strings.Cut(strings.TrimSpace(line), " ")
+		if strings.EqualFold(name, extension) {
+			return true
+		}
+	}
+	return false
+}
+
+func attributes(client Client) string {
+	values := []string{"ADDR=" + or(client.Address), "NAME=" + or(client.Name)}
+	if client.Helo != "" {
+		values = append(values, "HELO="+client.Helo)
+	}
+	return strings.Join(values, " ")
+}
+
+func or(value string) string {
+	if value == "" {
+		return Unavailable
+	}
+	return value
+}

--- a/backend/mail/inbound/xclient_test.go
+++ b/backend/mail/inbound/xclient_test.go
@@ -1,0 +1,191 @@
+package inbound
+
+import (
+	"bufio"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/syncloud/redirect/model"
+)
+
+type fakeResolver struct {
+	names map[string]string
+}
+
+func (f *fakeResolver) Name(address string) string {
+	return f.names[address]
+}
+
+func testResolver() Resolver {
+	return &fakeResolver{names: map[string]string{"203.0.113.1": "mail.example.net"}}
+}
+
+type xclientDevice struct {
+	address    string
+	advertise  bool
+	mutex      sync.Mutex
+	announced  string
+	greetings  int
+	recipients []string
+	body       string
+}
+
+func startXclientDevice(advertise bool) (*xclientDevice, func(), error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, err
+	}
+	device := &xclientDevice{address: listener.Addr().String(), advertise: advertise}
+	go func() {
+		for {
+			connection, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go device.serve(connection)
+		}
+	}()
+	return device, func() { _ = listener.Close() }, nil
+}
+
+func (d *xclientDevice) serve(connection net.Conn) {
+	defer func() { _ = connection.Close() }()
+	reader := bufio.NewReader(connection)
+	write := func(line string) { _, _ = connection.Write([]byte(line + "\r\n")) }
+
+	write("220 device.syncloud.it ESMTP")
+	d.count()
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+		command := strings.TrimRight(line, "\r\n")
+		upper := strings.ToUpper(command)
+		switch {
+		case strings.HasPrefix(upper, "EHLO"):
+			if d.advertise {
+				write("250-device.syncloud.it")
+				write("250 XCLIENT ADDR NAME HELO")
+			} else {
+				write("250 device.syncloud.it")
+			}
+		case strings.HasPrefix(upper, "XCLIENT"):
+			d.record(strings.TrimSpace(command[len("XCLIENT"):]))
+			write("220 device.syncloud.it ESMTP")
+			d.count()
+		case strings.HasPrefix(upper, "MAIL FROM"):
+			write("250 2.1.0 Ok")
+		case strings.HasPrefix(upper, "RCPT TO"):
+			d.addRecipient(command)
+			write("250 2.1.5 Ok")
+		case strings.HasPrefix(upper, "DATA"):
+			write("354 End data with <CR><LF>.<CR><LF>")
+			d.readBody(reader)
+			write("250 2.0.0 Ok")
+		case strings.HasPrefix(upper, "QUIT"):
+			write("221 2.0.0 Bye")
+			return
+		default:
+			write("250 2.0.0 Ok")
+		}
+	}
+}
+
+func (d *xclientDevice) readBody(reader *bufio.Reader) {
+	var body strings.Builder
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			break
+		}
+		if strings.TrimRight(line, "\r\n") == "." {
+			break
+		}
+		body.WriteString(line)
+	}
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.body = body.String()
+}
+
+func (d *xclientDevice) record(attributes string) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.announced = attributes
+}
+
+func (d *xclientDevice) count() {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.greetings++
+}
+
+func (d *xclientDevice) addRecipient(command string) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.recipients = append(d.recipients, command)
+}
+
+func (d *xclientDevice) got() (string, int, string) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	return d.announced, d.greetings, d.body
+}
+
+func TestXclient_AnnouncesTheRealClientToTheDevice(t *testing.T) {
+	device, stopDevice, err := startXclientDevice(true)
+	assert.NoError(t, err)
+	defer stopDevice()
+	address, stop, err := relayed(&fakeDialer{devices: map[string]string{"alice.syncloud.it": device.address}},
+		map[string]*model.Domain{"alice.syncloud.it": relayDomain("alice.syncloud.it")})
+	assert.NoError(t, err)
+	defer stop()
+
+	assert.NoError(t, deliver(address, "user@alice.syncloud.it"))
+
+	announced, _, body := device.got()
+	assert.Contains(t, announced, "ADDR=203.0.113.1")
+	assert.Contains(t, announced, "NAME=mail.example.net")
+	assert.Contains(t, announced, "HELO=localhost")
+	assert.Contains(t, body, "Subject: hello")
+}
+
+func TestXclient_DeviceWithoutTheExtensionStillGetsTheMessage(t *testing.T) {
+	device, stopDevice, err := startXclientDevice(false)
+	assert.NoError(t, err)
+	defer stopDevice()
+	address, stop, err := relayed(&fakeDialer{devices: map[string]string{"alice.syncloud.it": device.address}},
+		map[string]*model.Domain{"alice.syncloud.it": relayDomain("alice.syncloud.it")})
+	assert.NoError(t, err)
+	defer stop()
+
+	assert.NoError(t, deliver(address, "user@alice.syncloud.it"))
+
+	announced, greetings, body := device.got()
+	assert.Equal(t, "", announced)
+	assert.Equal(t, 1, greetings)
+	assert.Contains(t, body, "Subject: hello")
+}
+
+func TestXclient_UnresolvedClientIsReportedUnavailable(t *testing.T) {
+	device, stopDevice, err := startXclientDevice(true)
+	assert.NoError(t, err)
+	defer stopDevice()
+	connection, err := net.Dial("tcp", device.address)
+	assert.NoError(t, err)
+	defer func() { _ = connection.Close() }()
+
+	announced, err := Announce(connection, "mx.syncloud.it", Client{Address: "198.51.100.7"})
+	assert.NoError(t, err)
+	defer func() { _ = announced.Close() }()
+
+	attributes, greetings, _ := device.got()
+	assert.Contains(t, attributes, "ADDR=198.51.100.7")
+	assert.Contains(t, attributes, "NAME="+Unavailable)
+	assert.NotContains(t, attributes, "HELO=")
+	assert.Equal(t, 2, greetings)
+}


### PR DESCRIPTION
Mail that reaches a device through the tunnel arrives over a unix socket, so postfix reports every sender as `localhost[127.0.0.1]`:

```
postfix/tunnel/smtpd[19872]: connect from localhost[127.0.0.1]
```

Anything on the device that reads the client address is therefore judging the relay rather than the sender. That makes spf, dnsbl, greylisting and reputation scoring useless there, which is what this unblocks.

Redirect has the address already, so it announces it with `XCLIENT` before handing the session over, along with the reverse name and the helo the sender used.

### Compatibility

The extension is only used when the device offers it. Every device in the field today does not, and those sessions are left exactly as they were, so mail keeps flowing while devices are still on older versions. That path is covered by a test rather than left to assumption.

### Why the preamble is done by hand

`go-smtp`'s client greets the server itself and does not expose a way to send an arbitrary command, so the greeting and `EHLO` are done directly and the connection is handed over afterwards with a greeting spliced in front of the stream. The buffered reader is carried across rather than the raw socket, so nothing already read is dropped.

### Tests

- the device is told the real address, name and helo
- a device without the extension still receives the message
- an address that does not resolve is announced as `[UNAVAILABLE]`

Green on all three arches (build 1493).
