### PR TITLE
Greet the device with the name the sender gave

### DIFF
--- a/backend/mail/inbound/session.go
+++ b/backend/mail/inbound/session.go
@@ -109,7 +109,7 @@ func (s *Session) connect(domain string) error {
 			zap.String("domain", domain), zap.Error(err))
 		return tryAgain(ErrUnreachable, smtp.EnhancedCode{4, 4, 1})
 	}
-	announced, err := Announce(connection, s.hostname, Client{
+	announced, helo, err := Announce(connection, s.hostname, Client{
 		Address: s.peer,
 		Name:    s.resolver.Name(s.peer),
 		Helo:    s.helo,
@@ -121,7 +121,7 @@ func (s *Session) connect(domain string) error {
 		return relayError(err)
 	}
 	client := smtp.NewClient(announced)
-	if err := client.Hello(s.hostname); err != nil {
+	if err := client.Hello(helo); err != nil {
 		_ = client.Close()
 		return relayError(err)
 	}

--- a/backend/mail/inbound/xclient.go
+++ b/backend/mail/inbound/xclient.go
@@ -25,28 +25,32 @@ func (g *greeted) Read(p []byte) (int, error) {
 	return g.reader.Read(p)
 }
 
-func Announce(connection net.Conn, hostname string, client Client) (net.Conn, error) {
+func Announce(connection net.Conn, hostname string, client Client) (net.Conn, string, error) {
 	text := textproto.NewConn(connection)
 	if _, _, err := text.ReadResponse(220); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if err := text.PrintfLine("EHLO %s", hostname); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	_, capabilities, err := text.ReadResponse(250)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
+	helo := hostname
 	if supports(capabilities, "XCLIENT") {
 		if err := text.PrintfLine("XCLIENT %s", attributes(client)); err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		if _, _, err := text.ReadResponse(220); err != nil {
-			return nil, err
+			return nil, "", err
+		}
+		if client.Helo != "" {
+			helo = client.Helo
 		}
 	}
 	greeting := strings.NewReader(fmt.Sprintf("220 %s ESMTP\r\n", hostname))
-	return &greeted{Conn: connection, reader: io.MultiReader(greeting, text.R)}, nil
+	return &greeted{Conn: connection, reader: io.MultiReader(greeting, text.R)}, helo, nil
 }
 
 func supports(capabilities string, extension string) bool {

--- a/backend/mail/inbound/xclient_test.go
+++ b/backend/mail/inbound/xclient_test.go
@@ -29,6 +29,7 @@ type xclientDevice struct {
 	mutex      sync.Mutex
 	announced  string
 	greetings  int
+	helos      []string
 	recipients []string
 	body       string
 }
@@ -67,6 +68,7 @@ func (d *xclientDevice) serve(connection net.Conn) {
 		upper := strings.ToUpper(command)
 		switch {
 		case strings.HasPrefix(upper, "EHLO"):
+			d.addHelo(strings.TrimSpace(command[len("EHLO"):]))
 			if d.advertise {
 				write("250-device.syncloud.it")
 				write("250 XCLIENT ADDR NAME HELO")
@@ -124,6 +126,18 @@ func (d *xclientDevice) count() {
 	d.greetings++
 }
 
+func (d *xclientDevice) addHelo(name string) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.helos = append(d.helos, name)
+}
+
+func (d *xclientDevice) greeted() []string {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	return append([]string(nil), d.helos...)
+}
+
 func (d *xclientDevice) addRecipient(command string) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
@@ -154,6 +168,34 @@ func TestXclient_AnnouncesTheRealClientToTheDevice(t *testing.T) {
 	assert.Contains(t, body, "Subject: hello")
 }
 
+func TestXclient_DeviceIsGreetedWithTheClientHeloAfterTheReset(t *testing.T) {
+	device, stopDevice, err := startXclientDevice(true)
+	assert.NoError(t, err)
+	defer stopDevice()
+	address, stop, err := relayed(&fakeDialer{devices: map[string]string{"alice.syncloud.it": device.address}},
+		map[string]*model.Domain{"alice.syncloud.it": relayDomain("alice.syncloud.it")})
+	assert.NoError(t, err)
+	defer stop()
+
+	assert.NoError(t, deliver(address, "user@alice.syncloud.it"))
+
+	assert.Equal(t, []string{"mx.syncloud.it", "localhost"}, device.greeted())
+}
+
+func TestXclient_DeviceWithoutTheExtensionKeepsTheRelayHelo(t *testing.T) {
+	device, stopDevice, err := startXclientDevice(false)
+	assert.NoError(t, err)
+	defer stopDevice()
+	address, stop, err := relayed(&fakeDialer{devices: map[string]string{"alice.syncloud.it": device.address}},
+		map[string]*model.Domain{"alice.syncloud.it": relayDomain("alice.syncloud.it")})
+	assert.NoError(t, err)
+	defer stop()
+
+	assert.NoError(t, deliver(address, "user@alice.syncloud.it"))
+
+	assert.Equal(t, []string{"mx.syncloud.it", "mx.syncloud.it"}, device.greeted())
+}
+
 func TestXclient_DeviceWithoutTheExtensionStillGetsTheMessage(t *testing.T) {
 	device, stopDevice, err := startXclientDevice(false)
 	assert.NoError(t, err)
@@ -179,8 +221,9 @@ func TestXclient_UnresolvedClientIsReportedUnavailable(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { _ = connection.Close() }()
 
-	announced, err := Announce(connection, "mx.syncloud.it", Client{Address: "198.51.100.7"})
+	announced, helo, err := Announce(connection, "mx.syncloud.it", Client{Address: "198.51.100.7"})
 	assert.NoError(t, err)
+	assert.Equal(t, "mx.syncloud.it", helo)
 	defer func() { _ = announced.Close() }()
 
 	attributes, greetings, _ := device.got()


### PR DESCRIPTION
## What

Mail carried in over the tunnel is announced to the device with `XCLIENT`, which already carries the connecting client's `ADDR`, `NAME` and `HELO`. Postfix restarts the session when it accepts `XCLIENT`, so the relay must greet again — and it was greeting with `s.hostname`, silently overwriting the `HELO` that `XCLIENT` had just set.

`Announce` now returns the name the follow-up `EHLO` should use, and `session.go` greets with it.

## Why it matters

Every inbound message reached the device claiming to come from `mx.syncloud.it`, which has no A record. On a live device the effect was visible on **100% of inbound mail**, wanted or not:

```
HFILTER_HELO_IP_A           +1.0   [mx.syncloud.it]
HFILTER_HELO_NORES_A_OR_MX  +0.3   [mx.syncloud.it]
```

Legitimate senders were carrying the same +1.3 as everything else, so the check separated nothing. Confirmed against a real delivery: the recorded `Received: from mx.syncloud.it (fout-b7-smtp.messagingengine.com [202.12.124.150])` shows `ADDR`/`NAME` surviving and `HELO` being lost, and `fout-b7-smtp.messagingengine.com` resolves to exactly that connecting IP — so the symbol would not have fired had the real greeting been passed through.

## Scope

Deliberately limited to the `XCLIENT` path. A device that doesn't advertise the extension keeps the relay's name: nothing was announced to it, so the connection genuinely is the relay's and its own name is the honest one.

## Tests

Two new cases covering both paths. I verified the new test is meaningful by reverting the fix — it fails with exactly the production symptom:

```
- (string) (len=9) "localhost"
+ (string) (len=14) "mx.syncloud.it"
```

Full `backend` suite green.