### PR TITLE
Log when a click id is rejected instead of dropping it silently

### DIFF
--- a/backend/service/users.go
+++ b/backend/service/users.go
@@ -148,6 +148,10 @@ func (u *Users) CreateNewUser(request model.UserCreateRequest) (*model.User, err
 	}
 
 	updateToken := utils.Uuid()
+	gclid, gclidRejected := validation.SanitizeGclid(request.Gclid)
+	if gclidRejected != "" {
+		log.Printf("gclid rejected, ad attribution dropped: %s", gclidRejected)
+	}
 	user := &model.User{
 		Email:               *email,
 		PasswordHash:        Hash(*password),
@@ -155,7 +159,7 @@ func (u *Users) CreateNewUser(request model.UserCreateRequest) (*model.User, err
 		UpdateToken:         updateToken,
 		Timestamp:           time.Now(),
 		NotificationEnabled: true,
-		Gclid:               validation.SanitizeGclid(request.Gclid),
+		Gclid:               gclid,
 	}
 
 	userId, err := u.db.InsertUser(user)

--- a/backend/validation/validator.go
+++ b/backend/validation/validator.go
@@ -89,13 +89,24 @@ func (v *FieldValidator) Domain(domain *string, field string, mainDomain string)
 	}
 }
 
-var gclidPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,128}$`)
+const GclidMaxLength = 128
 
-func SanitizeGclid(gclid *string) *string {
-	if gclid == nil || !gclidPattern.MatchString(*gclid) {
-		return nil
+var gclidPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+func SanitizeGclid(gclid *string) (*string, string) {
+	if gclid == nil {
+		return nil, ""
 	}
-	return gclid
+	if *gclid == "" {
+		return nil, "empty"
+	}
+	if len(*gclid) > GclidMaxLength {
+		return nil, fmt.Sprintf("longer than %d characters: %d", GclidMaxLength, len(*gclid))
+	}
+	if !gclidPattern.MatchString(*gclid) {
+		return nil, "contains characters outside A-Za-z0-9_-"
+	}
+	return gclid, ""
 }
 
 func (v *FieldValidator) Email(email *string) *string {

--- a/backend/validation/validator_test.go
+++ b/backend/validation/validator_test.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/syncloud/redirect/model"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -49,34 +50,46 @@ func TestEmailValid(t *testing.T) {
 	assert.Equal(t, "user@example.com", *result)
 }
 
+func sanitized(t *testing.T, gclid *string) *string {
+	value, reason := SanitizeGclid(gclid)
+	assert.Equal(t, "", reason)
+	return value
+}
+
+func rejected(t *testing.T, gclid string) string {
+	value, reason := SanitizeGclid(&gclid)
+	assert.Nil(t, value)
+	assert.NotEqual(t, "", reason, "a rejection must explain itself or it cannot be logged")
+	return reason
+}
+
 func TestSanitizeGclidNil(t *testing.T) {
-	assert.Nil(t, SanitizeGclid(nil))
+	assert.Nil(t, sanitized(t, nil))
 }
 
 func TestSanitizeGclidValid(t *testing.T) {
 	gclid := "Cj0KCQjw_-GFBhDeARIsACH_kdY-abc_123"
-	assert.Equal(t, gclid, *SanitizeGclid(&gclid))
+	assert.Equal(t, gclid, *sanitized(t, &gclid))
 }
 
 func TestSanitizeGclidEmpty(t *testing.T) {
-	gclid := ""
-	assert.Nil(t, SanitizeGclid(&gclid))
+	assert.Equal(t, "empty", rejected(t, ""))
 }
 
 func TestSanitizeGclidTooLong(t *testing.T) {
-	gclid := strings.Repeat("a", 129)
-	assert.Nil(t, SanitizeGclid(&gclid))
+	reason := rejected(t, strings.Repeat("a", GclidMaxLength+1))
+	assert.Contains(t, reason, "longer than")
+	assert.Contains(t, reason, strconv.Itoa(GclidMaxLength+1))
 }
 
 func TestSanitizeGclidMaxLength(t *testing.T) {
-	gclid := strings.Repeat("a", 128)
-	assert.Equal(t, gclid, *SanitizeGclid(&gclid))
+	gclid := strings.Repeat("a", GclidMaxLength)
+	assert.Equal(t, gclid, *sanitized(t, &gclid))
 }
 
 func TestSanitizeGclidRejectsInjection(t *testing.T) {
 	for _, bad := range []string{"abc'; drop table user;--", "<script>x</script>", "abc def", "abc\n", "../../etc"} {
-		value := bad
-		assert.Nil(t, SanitizeGclid(&value), bad)
+		assert.Contains(t, rejected(t, bad), "characters outside", bad)
 	}
 }
 


### PR DESCRIPTION
`SanitizeGclid` returned `nil` for anything failing its pattern, and `CreateNewUser` stored that `nil` without comment. A registration arriving from a paid ad whose click id the validator disliked therefore looked **identical** to a registration from someone who never clicked an ad — no log line, no metric, no column to tell them apart.

## Why now

The campaign is live and clicks are arriving. The character class is certainly right — real click ids are base64url, so `A-Za-z0-9_-` covers them — but **the 128 character limit is a guess**. Google has lengthened click ids over the years, and nothing in the current code would reveal the day they outgrow the cap. Attribution would simply stop, and the first visible symptom would be a conversion rate of zero, indistinguishable from ads that do not work.

That is the failure mode worth removing: not the drop itself, but the silence around it.

## What changed

- `SanitizeGclid` returns `(*string, string)` — the value, and a reason when it is rejected.
- `CreateNewUser` logs the reason.
- `GclidMaxLength` is now a named constant instead of a literal inside the regex.

**Behaviour is otherwise unchanged.** Exactly the same ids are accepted and the same ones rejected. I deliberately did **not** raise the limit — whether 128 is right is a separate decision from being able to see when it bites, and I would rather land the visibility first and change the value on evidence.

The logged reason is the length or which rule was broken, never the click id itself.

## Tests

Existing cases kept and extended to assert the reason, so a future refactor cannot reintroduce a silent rejection:

```
TestSanitizeGclidNil            PASS
TestSanitizeGclidValid          PASS
TestSanitizeGclidEmpty          PASS
TestSanitizeGclidTooLong        PASS
TestSanitizeGclidMaxLength      PASS
TestSanitizeGclidRejectsInjection PASS
```

`go build`, `go vet` and `go test ./validation/... ./service/...` all pass locally.