### PR TITLE
Stop writing PayPal requests and responses to stdout

### DIFF
--- a/backend/subscription/paypal.go
+++ b/backend/subscription/paypal.go
@@ -5,7 +5,6 @@ import (
 	"github.com/plutov/paypal/v4"
 	"github.com/syncloud/redirect/model"
 	"go.uber.org/zap"
-	"os"
 )
 
 type PayPal struct {
@@ -23,8 +22,6 @@ func New(clientID, secretID, url, planMonthlyId, planAnnualId, planMaxMonthlyId,
 	if err != nil {
 		return nil, err
 	}
-	c.SetLog(os.Stdout)
-
 	return &PayPal{
 		client:           c,
 		clientId:         clientID,


### PR DESCRIPTION
The PayPal client was built with `SetLog(os.Stdout)`. In `plutov/paypal` that assigns `c.Log`, and `Send` then runs:

```go
if c.Log != nil {
    if reqDump, err := httputil.DumpRequestOut(req, true); err == nil {   // true = with body
...
if c.Log != nil {
    if respDump, err := httputil.DumpResponse(resp, true); err == nil {   // true = with body
```

Both include headers and bodies, so every PayPal interaction was written verbatim to the container log — authentication headers and subscriber details along with it. Application logs are not an appropriate place for either, and a container log gets none of the handling a secret store or a customer record does.

## The change

Remove the `SetLog` call and the now-unused `os` import. Three deleted lines.

Nothing in our code reads `c.Log`, and the struct already carries a `zap.Logger` for anything we genuinely want recorded, so behaviour is otherwise unchanged.

I did not replace it with a debug-flag version. A flag that dumps this material when enabled is the same hazard with an extra step, and it would be switched on to diagnose something and left on.

Stripe was checked and does not do the same thing; this was the only `os.Stdout` writer in the backend.

`go build`, `go vet` and the full `go test ./...` pass.