### PR TITLE
Record image downloads and redirect to the release asset

### DIFF
--- a/backend/metrics/metrics.go
+++ b/backend/metrics/metrics.go
@@ -6,6 +6,7 @@ type Metrics struct {
 	requests  *prometheus.CounterVec
 	dnsClient *prometheus.CounterVec
 	cleaner   *prometheus.CounterVec
+	download  *prometheus.CounterVec
 	rogue     *RogueDevices
 }
 
@@ -32,6 +33,13 @@ func New() *Metrics {
 			},
 			[]string{"result"},
 		),
+		download: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "redirect_download_total",
+				Help: "Device image download links followed, by board and whether the visitor arrived from an ad.",
+			},
+			[]string{"board", "source"},
+		),
 		rogue: NewRogueDevices(),
 	}
 }
@@ -48,6 +56,10 @@ func (m *Metrics) Cleaner(result string) {
 	m.cleaner.WithLabelValues(result).Inc()
 }
 
+func (m *Metrics) Download(board, source string) {
+	m.download.WithLabelValues(board, source).Inc()
+}
+
 func (m *Metrics) Rogue(platformVersion, token string) {
 	m.rogue.Mark(platformVersion, token)
 }
@@ -56,6 +68,7 @@ func (m *Metrics) Describe(ch chan<- *prometheus.Desc) {
 	m.requests.Describe(ch)
 	m.dnsClient.Describe(ch)
 	m.cleaner.Describe(ch)
+	m.download.Describe(ch)
 	m.rogue.Describe(ch)
 }
 
@@ -63,5 +76,6 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 	m.requests.Collect(ch)
 	m.dnsClient.Collect(ch)
 	m.cleaner.Collect(ch)
+	m.download.Collect(ch)
 	m.rogue.Collect(ch)
 }

--- a/backend/rest/download.go
+++ b/backend/rest/download.go
@@ -1,0 +1,46 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/gorilla/mux"
+	"go.uber.org/zap"
+)
+
+const imageReleaseUrl = "https://github.com/syncloud/image/releases/download/%s/syncloud-%s-%s.%s.xz"
+
+var (
+	boardPattern   = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$`)
+	versionPattern = regexp.MustCompile(`^[0-9]{2}\.[0-9]{2}\.[0-9]{2}$`)
+	imageFormats   = map[string]bool{"img": true, "vdi": true}
+)
+
+func (w *Www) Download(writer http.ResponseWriter, req *http.Request) {
+	board := mux.Vars(req)["board"]
+	version := req.URL.Query().Get("version")
+	format := req.URL.Query().Get("format")
+	if format == "" {
+		format = "img"
+	}
+	if !boardPattern.MatchString(board) || !versionPattern.MatchString(version) || !imageFormats[format] {
+		w.logger.Info("download rejected",
+			zap.String("board", board), zap.String("version", version),
+			zap.String("format", format))
+		http.Error(writer, "unknown image", http.StatusNotFound)
+		return
+	}
+
+	source := "direct"
+	if req.URL.Query().Get("gclid") != "" {
+		source = "ad"
+	}
+	w.metrics.Download(board, source)
+	w.logger.Info("download", zap.String("board", board),
+		zap.String("version", version), zap.String("format", format),
+		zap.String("source", source))
+
+	http.Redirect(writer, req,
+		fmt.Sprintf(imageReleaseUrl, version, board, version, format), http.StatusFound)
+}

--- a/backend/rest/download_test.go
+++ b/backend/rest/download_test.go
@@ -1,0 +1,64 @@
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/syncloud/redirect/metrics"
+	"go.uber.org/zap"
+)
+
+func downloadRequest(t *testing.T, target string) *httptest.ResponseRecorder {
+	w := &Www{metrics: metrics.New(), logger: zap.NewNop()}
+	r := mux.NewRouter()
+	r.HandleFunc("/download/{board}", w.Download).Methods("GET")
+	recorder := httptest.NewRecorder()
+	r.ServeHTTP(recorder, httptest.NewRequest("GET", target, nil))
+	return recorder
+}
+
+func TestDownloadRedirectsToTheImage(t *testing.T) {
+	response := downloadRequest(t, "/download/raspberrypi-64?version=26.06.01")
+	assert.Equal(t, http.StatusFound, response.Code)
+	assert.Equal(t,
+		"https://github.com/syncloud/image/releases/download/26.06.01/syncloud-raspberrypi-64-26.06.01.img.xz",
+		response.Header().Get("Location"))
+}
+
+func TestDownloadServesTheVirtualBoxImage(t *testing.T) {
+	response := downloadRequest(t, "/download/amd64?version=26.07.01&format=vdi")
+	assert.Equal(t, http.StatusFound, response.Code)
+	assert.Equal(t,
+		"https://github.com/syncloud/image/releases/download/26.07.01/syncloud-amd64-26.07.01.vdi.xz",
+		response.Header().Get("Location"))
+}
+
+func TestDownloadRejectsUnknownFormat(t *testing.T) {
+	for _, format := range []string{"exe", "img.xz", "../img", "IMG"} {
+		response := downloadRequest(t, "/download/amd64?version=26.07.01&format="+format)
+		assert.Equal(t, http.StatusNotFound, response.Code, format)
+	}
+}
+
+func TestDownloadRejectsUnknownVersionFormat(t *testing.T) {
+	for _, version := range []string{"", "latest", "26.6.1", "../../etc", "26.06.01/x"} {
+		response := downloadRequest(t, "/download/raspberrypi-64?version="+version)
+		assert.Equal(t, http.StatusNotFound, response.Code, version)
+	}
+}
+
+func TestDownloadRejectsBoardOutsideTheCharacterSet(t *testing.T) {
+	for _, board := range []string{"Raspberry", "pi_64", "pi.64", "-pi", "pi-", "a%2f..%2fb"} {
+		response := downloadRequest(t, "/download/"+board+"?version=26.06.01")
+		assert.NotEqual(t, http.StatusFound, response.Code, board)
+	}
+}
+
+func TestDownloadCannotBeRedirectedOffGithub(t *testing.T) {
+	response := downloadRequest(t, "/download/raspberrypi-64?version=26.06.01&url=https://evil.example.com")
+	assert.Equal(t, http.StatusFound, response.Code)
+	assert.Contains(t, response.Header().Get("Location"), "https://github.com/syncloud/image/")
+}

--- a/backend/rest/www.go
+++ b/backend/rest/www.go
@@ -152,6 +152,7 @@ func (w *Www) Limited(next func(http.ResponseWriter, *http.Request)) func(http.R
 func (w *Www) Start() error {
 
 	r := mux.NewRouter()
+	r.HandleFunc("/download/{board}", w.Limited(w.Download)).Methods("GET")
 	r.HandleFunc("/user/reset_password", w.Limited(Handle(w.WebUserPasswordReset))).Methods("POST")
 	r.HandleFunc("/user/set_password", Handle(w.UserSetPassword)).Methods("POST")
 	r.HandleFunc("/user/activate", Handle(w.WebUserActivate)).Methods("POST")


### PR DESCRIPTION
Download links live on the GitHub wiki and point straight at release assets, so the moment someone actually takes an image is invisible to us. GitHub gives an aggregate count per asset and nothing else — no path, no attribution, no way to separate a real visitor from CI or a mirror.

That step is where the funnel appears to lose nearly everyone. Roughly a hundred downloads a month produce about one device activation, and none of the intervening steps are observable. Payment is not the leak — almost everyone who gets a device running subscribes.

## What this adds

`GET /download/{board}?version=X` — records the board and whether the visitor carried a `gclid`, then 302s to the GitHub asset. Serving the file stays with GitHub; only the click becomes ours.

```
/download/raspberrypi-64?version=26.06.01
  -> https://github.com/syncloud/image/releases/download/26.06.01/syncloud-raspberrypi-64-26.06.01.img.xz
```

Counts land in `redirect_download_total{board,source}`, alongside the metrics Grafana already reads. No third-party analytics, no cookie, no consent banner — it is a server-side counter on our own domain.

## On safety

The target URL is built from a fixed template, never taken from a parameter, so this cannot be turned into an open redirect. Both `board` and `version` are matched against patterns and anything else is a 404. The handler is rate limited like the other public endpoints.

Tests cover the happy path, malformed versions, boards outside the character set, and an explicit attempt to redirect off github.com.

## Scope

Backend only. Nothing links here yet — the `/download` page in syncloud.org follows in a separate PR, and that is the part worth looking at on uat. Merging this first just means the endpoint exists when the page needs it.

`go build`, `go vet` and the full `go test ./...` pass.